### PR TITLE
Removed one no longer needed import

### DIFF
--- a/fastworkflow/train/__main__.py
+++ b/fastworkflow/train/__main__.py
@@ -9,7 +9,7 @@ import fastworkflow
 from fastworkflow.command_routing_definition import ModuleType
 from fastworkflow.model_pipeline_training import train, get_route_layer_filepath_model
 from fastworkflow.utils.generate_param_examples import generate_dspy_examples
-from fastworkflow.param_workflow_training import param_train
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
The import statement is not needed and cause runtime error in train.

## Summary by Sourcery

Bug Fixes:
- Remove unused import of param_train from __main__.py to prevent training runtime failures