### PR TITLE
docs: Add --assistant CLI flag and LOG_LEVEL env var to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ This step builds the NLP models that help the workflow understand user commands.
 Once training is complete, run the interactive assistant:
 
 ```sh
+# Run in agentic mode (default)
 fastworkflow run ./examples/hello_world ./examples/fastworkflow.env ./examples/fastworkflow.passwords.env
+
+# Or run in assistant (non-agentic) mode
+fastworkflow run ./examples/hello_world ./examples/fastworkflow.env ./examples/fastworkflow.passwords.env --assistant
 ```
 
 You will be greeted with a `User >` prompt. Try it out by asking "what can you do?" or "add 49 + 51"!
@@ -240,8 +244,11 @@ fastworkflow build --app-dir <app_dir> --workflow-folderpath <workflow_dir>
 # Train a workflow's intent detection models
 fastworkflow train <workflow_dir> <env_file> <passwords_file>
 
-# Run a workflow
+# Run a workflow (agentic mode, default)
 fastworkflow run <workflow_dir> <env_file> <passwords_file>
+
+# Run a workflow in assistant (non-agentic) mode
+fastworkflow run <workflow_dir> <env_file> <passwords_file> --assistant
 ```
 
 > [!tip]
@@ -669,6 +676,7 @@ This single command will generate the `greet.py` command, `get_properties` and `
 | Variable | Purpose | When Needed | Default |
 |:---|:---|:---|:---|
 | `SPEEDDICT_FOLDERNAME` | Directory name for workflow contexts | Always | `___workflow_contexts` |
+| `LOG_LEVEL` | Logging level for fastWorkflow and uvicorn (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) | Optional | `INFO` |
 | `LLM_SYNDATA_GEN` | LiteLLM model string for synthetic utterance generation | `train` | `mistral/mistral-small-latest` |
 | `LLM_PARAM_EXTRACTION` | LiteLLM model string for parameter extraction | `train`, `run` | `mistral/mistral-small-latest` |
 | `LLM_RESPONSE_GEN` | LiteLLM model string for response generation | `run` | `mistral/mistral-small-latest` |


### PR DESCRIPTION
## Documentation Update

Updates `README.md` to reflect recent code changes since the last docs update (65cf2ea).

### Changes

**`--assistant` flag for CLI** (v2.17.32, v2.17.33)
- Added `--assistant` flag usage to the CLI Command Reference section
- Added assistant mode example to the Quick Start "Step 4: Run the Example" section
- Related commits: 51cf15e, ee3c3ba

**`LOG_LEVEL` environment variable** (v2.17.29)
- Added `LOG_LEVEL` to the Environment Variables Reference table — controls logging level for both fastWorkflow and uvicorn
- Related commit: e5138d1

### Skipped (no docs needed)
- v2.17.28: Internal bug fixes and logging refinements
- v2.17.30: Internal error logging for FastAPI timeouts
- v2.17.31: Internal bug fix in ProbeAccessLogFilter
- v2.17.34: Internal null check in collect_trace_events

_This PR was generated with [Oz](https://www.warp.dev/oz)._

## Summary by Sourcery

Update README to document the new assistant CLI mode and logging configuration options.

Documentation:
- Document assistant (non-agentic) mode usage in quick start and CLI command reference examples.
- Add LOG_LEVEL environment variable to the environment variables reference table, including supported values and default.