### PR TITLE
Add insights distillation, robust parameter extraction, and agent replanning fidelity

### DIFF
--- a/fastworkflow/_workflows/command_metadata_extraction/parameter_extraction.py
+++ b/fastworkflow/_workflows/command_metadata_extraction/parameter_extraction.py
@@ -1,7 +1,9 @@
 import contextlib
 import sys
 import re
-from typing import Dict, List, Optional
+import json
+import ast
+from typing import Dict, List, Optional, Union, get_origin, get_args
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
@@ -22,6 +24,23 @@ INVALID_INFORMATION_ERRMSG = fastworkflow.get_env_var("INVALID_INFORMATION_ERRMS
 NOT_FOUND = fastworkflow.get_env_var("NOT_FOUND")
 INVALID = fastworkflow.get_env_var("INVALID")
 PARAMETER_EXTRACTION_ERROR_MSG = None
+
+
+def _unwrap_optional(field_type):
+    """
+    Unwrap ``Optional[X]`` / ``Union[X, None]`` to its underlying type.
+
+    Returns ``(inner_type, origin)`` where ``origin`` is ``get_origin`` of the
+    unwrapped type (e.g. ``list`` for ``Optional[List[str]]``). Non-optional
+    types are returned unchanged.
+    """
+    origin = get_origin(field_type)
+    if origin is Union:
+        non_none_types = [t for t in get_args(field_type) if t is not type(None)]
+        if non_none_types:
+            field_type = non_none_types[0]
+            origin = get_origin(field_type)
+    return field_type, origin
 
 
 class ParameterExtraction:
@@ -90,14 +109,22 @@ class ParameterExtraction:
             self.app_workflow, self.command_name, new_params
         )
 
-        # Set all the missing and invalid fields to None before storing
+        # Set all the missing and invalid fields to appropriate sentinel values before storing
         current_values = {
             field_name: getattr(new_params, field_name, None)
             for field_name in list(type(new_params).model_fields.keys())
         }
         for field_name in missing_invalid_fields:
             if field_name in current_values:
-                current_values[field_name] = NOT_FOUND
+                # Determine appropriate sentinel value based on field type
+                field_info = type(new_params).model_fields[field_name]
+                _, origin = _unwrap_optional(field_info.annotation)
+
+                # Use empty list for list fields, NOT_FOUND for others
+                if origin in (list, List):
+                    current_values[field_name] = []
+                else:
+                    current_values[field_name] = NOT_FOUND
         # Reconstruct the model instance without validation
         new_params = new_params.__class__.model_construct(**current_values)
 
@@ -233,11 +260,15 @@ class ParameterExtraction:
             value = getattr(params, field_name, None)
 
             if value in [
-                NOT_FOUND, 
+                NOT_FOUND,
                 None,
                 INVALID_INT_VALUE,
                 INVALID_FLOAT_VALUE
             ]:
+                continue
+
+            # Skip empty lists (sentinel for missing list fields)
+            if isinstance(value, list) and len(value) == 0:
                 continue
 
             display_name = " ".join(word.capitalize() for word in field_name.split('_'))
@@ -320,7 +351,22 @@ class ParameterExtraction:
             for field_name in field_names:
                 # Look for <field_name>value</field_name> pattern
                 pattern = rf'<{re.escape(field_name)}>(.+?)</{re.escape(field_name)}>'
-                if match := re.search(pattern, command, re.DOTALL):
+                # For list-typed fields, an agent may repeat the tag once per item
+                # (e.g. <item_ids>a</item_ids> <item_ids>b</item_ids>). re.search
+                # would keep only the first, silently dropping the rest, so collect
+                # ALL occurrences with findall and hand the list parser every value.
+                _, forigin = _unwrap_optional(
+                    command_parameters_class.model_fields[field_name].annotation
+                )
+                if forigin in (list, List):
+                    matches = re.findall(pattern, command, re.DOTALL)
+                    if len(matches) > 1:
+                        # Multiple repeated tags -> JSON array so the list parser
+                        # below collects every value (not just the first).
+                        extracted_data[field_name] = json.dumps([m.strip() for m in matches])
+                    elif len(matches) == 1:
+                        extracted_data[field_name] = matches[0].strip()
+                elif match := re.search(pattern, command, re.DOTALL):
                     parameter_value = match[1].strip()
                     extracted_data[field_name] = parameter_value
 
@@ -348,8 +394,66 @@ class ParameterExtraction:
                 else:
                     params_data[field_name] = None
 
-            # Update with extracted values
-            params_data |= extracted_data
+            # Parse and type-correct extracted values
+            for field_name, raw_value in extracted_data.items():
+                field_info = command_parameters_class.model_fields[field_name]
+                field_type, origin = _unwrap_optional(field_info.annotation)
+
+                # Handle list types with robust parsing
+                if origin in (list, List):
+                    inner_type = get_args(field_type)[0] if get_args(field_type) else str
+                    parsed_list = None
+
+                    # Try JSON array format
+                    if raw_value.startswith('[') and raw_value.endswith(']'):
+                        with contextlib.suppress(Exception):
+                            parsed = json.loads(raw_value)
+                            if isinstance(parsed, list):
+                                parsed_list = parsed
+
+                    # Try Python literal format
+                    if parsed_list is None:
+                        with contextlib.suppress(Exception):
+                            parsed = ast.literal_eval(raw_value)
+                            if isinstance(parsed, list):
+                                parsed_list = parsed
+
+                    # Try comma-separated format
+                    if parsed_list is None and ',' in raw_value:
+                        parsed_list = [item.strip().strip('"').strip("'") for item in raw_value.split(',')]
+
+                    # Try space-separated format
+                    if parsed_list is None and ' ' in raw_value and not any(c in raw_value for c in ['[', ']', '{', '}', '"', "'"]):
+                        parsed_list = [item.strip() for item in raw_value.split() if item.strip()]
+
+                    # Single value treated as single-item list
+                    if parsed_list is None:
+                        cleaned = raw_value.strip().strip('"').strip("'")
+                        parsed_list = [cleaned] if cleaned else []
+
+                    # Type-convert list items to match the inner type
+                    if parsed_list:
+                        typed_list = []
+                        for item in parsed_list:
+                            if inner_type is str:
+                                typed_list.append(str(item))
+                            elif inner_type is int:
+                                with contextlib.suppress(ValueError, TypeError):
+                                    typed_list.append(int(item))
+                            elif inner_type is float:
+                                with contextlib.suppress(ValueError, TypeError):
+                                    typed_list.append(float(item))
+                            elif isinstance(inner_type, type) and issubclass(inner_type, BaseModel) and isinstance(item, dict):
+                                with contextlib.suppress(Exception):
+                                    typed_list.append(inner_type(**item))
+                            else:
+                                typed_list.append(item)
+                        params_data[field_name] = typed_list
+                    else:
+                        params_data[field_name] = []
+                else:
+                    # Non-list types: use raw value as-is
+                    params_data[field_name] = raw_value
 
             # Construct model without validation
             return command_parameters_class.model_construct(**params_data)
@@ -380,7 +484,7 @@ class ParameterExtraction:
                 None,
                 INVALID_INT_VALUE,
                 INVALID_FLOAT_VALUE,
-            ]:
+            ] or (isinstance(value, list) and len(value) == 0):
                 fields_to_fill.append(field_name)
 
         if not fields_to_fill:

--- a/fastworkflow/_workflows/command_metadata_extraction/parameter_extraction.py
+++ b/fastworkflow/_workflows/command_metadata_extraction/parameter_extraction.py
@@ -36,8 +36,9 @@ def _unwrap_optional(field_type):
     """
     origin = get_origin(field_type)
     if origin is Union:
-        non_none_types = [t for t in get_args(field_type) if t is not type(None)]
-        if non_none_types:
+        if non_none_types := [
+            t for t in get_args(field_type) if t is not type(None)
+        ]:
             field_type = non_none_types[0]
             origin = get_origin(field_type)
     return field_type, origin

--- a/fastworkflow/chat_session.py
+++ b/fastworkflow/chat_session.py
@@ -101,14 +101,17 @@ class ChatSession:
     def __init__(
         self,
         run_as_agent: bool = False,
+        generate_insights: bool = False,
     ):
         """
         Initialize a chat session.
-        
+
         Args:
             run_as_agent: If True, use agent mode (DSPy-based tool selection).
                          If False (default), use traditional command execution.
-        
+            generate_insights: If True, enable teacher/student insights distillation
+                         on each agent turn (Topology A / CLI only).
+
         A chat session can run multiple workflows that share the same message queues.
         Use start_workflow() to start a specific workflow within this session.
         ChatSession is Topology A: ask_user blocks on the queue until the human answers.
@@ -116,6 +119,7 @@ class ChatSession:
         self._core = WorkflowExecutionContext(
             run_as_agent=run_as_agent,
             mirror_action_log_to_file=True,
+            generate_insights=generate_insights,
         )
 
         # Create queues for user messages and command outputs (CLI transport)
@@ -274,6 +278,11 @@ class ChatSession:
     def run_as_agent(self) -> bool:
         """Check if running in agent mode."""
         return self._core.run_as_agent
+
+    @property
+    def _distillation_insights_count(self) -> int:
+        """Number of insights extracted so far in insights-distillation mode."""
+        return self._core._distillation_insights_count
 
     @property
     def user_message_queue(self) -> Queue:

--- a/fastworkflow/cli.py
+++ b/fastworkflow/cli.py
@@ -273,6 +273,10 @@ def add_run_parser(subparsers):
         "--assistant", action="store_true", default=False,
         help="Run in assistant (non-agentic) mode. Default is agentic mode.",
     )
+    parser_run.add_argument(
+        "--generate_insights", action="store_true", default=False,
+        help="Enable insights-distillation mode: compare teacher and student agents, extract planning and execution insights on divergence.",
+    )
     parser_run.set_defaults(func=lambda args: run_with_defaults(args))
 
 def add_run_fastapi_mcp_parser(subparsers):

--- a/fastworkflow/distillation.py
+++ b/fastworkflow/distillation.py
@@ -1,0 +1,955 @@
+"""
+Runtime insights distillation module for planning and execution agents.
+
+Runs a teacher (large LLM) and student (small LLM) on the same user query,
+compares their planning decisions and execution actions, and extracts insights
+when the student diverges from the teacher.
+
+Two types of insights are extracted:
+- **Planning insights** ("what TO DO"): Prescriptive rules for the planner,
+  stored in `planning_agent_insights.md`
+- **Execution insights** ("what NOT to do"): Anti-patterns for the execution agent,
+  stored in `execution_agent_anti_patterns.md`
+
+Planning comparison uses the generated plans from `build_query_with_next_steps`.
+Execution comparison uses actual resolved command_name and parameters from action.jsonl.
+Full ReAct trajectories are passed to the insight extraction LLM for richer context.
+"""
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import dspy
+
+import fastworkflow
+from fastworkflow.utils.logging import logger
+from fastworkflow.utils import dspy_utils
+from fastworkflow.utils.chat_adapter import CommandsSystemPreludeAdapter
+
+# Per-turn log of executed actions, written by the workflow agent and read back
+# here to compare teacher vs. student trajectories.
+_ACTION_LOG_FILE = "action.jsonl"
+
+
+def _announce(title: str, subtitle: str = "", style: str = "cyan") -> None:
+    """
+    Print an observability banner for a distillation phase.
+
+    Distillation runs the agent twice (teacher then student) for a single user
+    message, so without this the user cannot tell which model produced which
+    output. Uses rich when available, else a plain print; never raises.
+    """
+    line = f"{title} — {subtitle}" if subtitle else title
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+        Console().print(Panel(line, style=style, expand=False))
+    except Exception:
+        print(f"\n=== {line} ===")
+
+
+def _reset_action_log() -> None:
+    """Remove the action log so the next agent pass starts from a clean slate."""
+    if os.path.exists(_ACTION_LOG_FILE):
+        os.remove(_ACTION_LOG_FILE)
+
+
+@dataclass
+class PlanningStep:
+    """Captures a single planning decision during agent execution."""
+    step_number: int           # For correlating multi-turn planning decisions
+    user_query: str
+    generated_plan: list[str]  # List of next steps from planner
+    reasoning: str = ""        # Chain-of-thought reasoning from the planner
+
+
+@dataclass
+class DistillationResult:
+    """Result of a distillation run for a single message."""
+    command_output: fastworkflow.CommandOutput
+    planning_insights_extracted: int = 0
+    execution_insights_extracted: int = 0
+
+    @property
+    def insights_extracted(self) -> int:
+        """Total insights (planning + execution) for backward compatibility."""
+        return self.planning_insights_extracted + self.execution_insights_extracted
+
+
+class PlanningInsightExtractionSignature(dspy.Signature):
+    """You are analyzing why a student planner generated an inferior plan compared to the teacher.
+
+    The planner's job is to break down a user request into a sequence of workflow commands.
+    A good plan identifies the RIGHT commands in the RIGHT order to fulfill the user's intent.
+
+    You are given:
+    - The user's original query
+    - Teacher's plan (the correct approach)
+    - Student's plan (may have issues)
+    - A summary of how the plans diverged
+    - Teacher's executed actions (what the teacher actually did — the ground truth)
+    - Student's executed actions (what the student actually did)
+
+    Use the executed actions to validate whether a plan led to correct behavior.
+    A plan that looks different but leads to the same correct actions may be acceptable.
+
+    CRITICAL — Context divergence awareness:
+    In multi-turn conversations, teacher and student may have different conversation
+    history context from prior turns. This can legitimately cause different planning
+    decisions. Before extracting a rule, analyze whether:
+    1. The planning difference was a genuine mistake (extract a rule)
+    2. The difference was justified by different context (return EMPTY)
+
+    YOUR TASK:
+
+    1. **Analyze and Find Root Cause**:
+    - Analyze the context each planner had access to
+    - Identify if there was a genuine planning mistake vs context-justified difference
+    - Look at Step 0 (initial planning) - this is usually where things go wrong
+    - What did the student plan that was incorrect?
+    - What did the teacher plan that was correct?
+    - What actions are MISSING from student's execution?
+
+    2. **Generate 1-3 Specific, Actionable Rules if genuine mistakes are found**:
+    - Rules should be PRESCRIPTIVE
+    - Rules should reference SPECIFIC command names
+    - Rules should prevent THIS EXACT failure from happening again
+    - Focus on the ROOT CAUSE, not symptoms
+
+    Return rules as: 1. [rule], 2. [rule], 3. [rule]
+    Return EMPTY if:
+    - Student's plan was reasonable given its context
+    - Rules duplicate existing insights"""
+
+    user_query: str = dspy.InputField()
+    teacher_plan: str = dspy.InputField(
+        desc="The correct plan generated by the teacher planner"
+    )
+    student_plan: str = dspy.InputField(
+        desc="The plan generated by the student planner (may have issues)"
+    )
+    divergence_summary: str = dspy.InputField(
+        desc="Summary of how teacher and student plans differ"
+    )
+    teacher_actions: str = dspy.InputField(
+        desc="Actions actually executed by the teacher agent (command names + parameters)"
+    )
+    student_actions: str = dspy.InputField(
+        desc="Actions actually executed by the student agent (command names + parameters)"
+    )
+    existing_insights: str = dspy.InputField(
+        desc="Already known planning rules (avoid duplicates)"
+    )
+    insights: str = dspy.OutputField(
+        desc="1-3 prescriptive, workflow-general rules as numbered list. "
+             "Return EMPTY if no genuine mistakes, context-justified, or duplicates."
+    )
+
+
+class InsightExtractionSignature(dspy.Signature):
+    """Analyze teacher vs student execution agent ReAct trajectories for the same user query.
+    Both trajectories contain the full sequence of thoughts, tool calls, arguments, and
+    observations (including any ask_user interactions and conversation history context).
+
+    A divergence summary describes the concrete differences in executed actions
+    (command names + parameters). Use the full trajectories to understand WHY
+    each agent made its choices.
+
+    CRITICAL — Multi-turn context awareness:
+    In multi-turn conversations, teacher and student may have received different
+    conversation context from prior turns (visible in observation_about_conversation_history
+    and ask_user observations). This can legitimately cause different action sequences.
+    Before extracting an insight, determine whether the student's actions were
+    reasonable given the context it actually had. Only extract insights for
+    genuine mistakes — NOT for context-justified differences.
+
+    Return insights as single-line bullet points (one per line, prefixed with "- ").
+    You may return multiple insights if there are multiple distinct mistakes.
+    Return EMPTY if differences are not genuine mistakes or duplicate existing insights."""
+    user_query: str = dspy.InputField()
+    teacher_trajectory: str = dspy.InputField(
+        desc="Teacher's full ReAct trajectory (reference/correct behavior)"
+    )
+    student_trajectory: str = dspy.InputField(
+        desc="Student's full ReAct trajectory (may contain mistakes)"
+    )
+    divergence_summary: str = dspy.InputField(
+        desc="Human-readable summary of action-level differences between teacher and student "
+             "(which commands/params differed, ordering differences, etc.)"
+    )
+    existing_insights: str = dspy.InputField(
+        desc="Already known anti-patterns (avoid duplicates)"
+    )
+    insights: str = dspy.OutputField(
+        desc="One or more anti-pattern insights as bullet points (each line prefixed with '- '). "
+             "Each insight should be a concise, actionable single-line point. "
+             "Return EMPTY if no genuine mistakes found, differences are context-justified, "
+             "or insights duplicate existing ones."
+    )
+
+
+class DistillationSession:
+    """Orchestrates a single distillation comparison for one user message."""
+
+    def __init__(self, wec: "fastworkflow.WorkflowExecutionContext"):
+        # `wec` is the WorkflowExecutionContext (session engine). Distillation is
+        # CLI/Topology-A only and drives its own agent passes over the WEC's state.
+        self.chat_session = wec
+        self.planning_insights_extracted: int = 0
+        self.execution_insights_extracted: int = 0
+
+    # ------------------------------------------------------------------
+    # State snapshot / restore
+    # ------------------------------------------------------------------
+
+    def snapshot_workflow_state(self) -> dict:
+        """Capture current workflow + CME state for later restoration."""
+        workflow = self.chat_session.get_active_workflow()
+        cme = self.chat_session.cme_workflow
+        return {
+            "workflow_dict": workflow._to_dict(),
+            "cme_dict": cme._to_dict(),
+            "conversation_history_len": len(
+                self.chat_session.conversation_history.messages
+            ),
+        }
+
+    def restore_workflow_state(self, snapshot: dict):
+        """Restore workflow + CME state from a prior snapshot."""
+        workflow = self.chat_session.get_active_workflow()
+        wd = snapshot["workflow_dict"]
+        workflow._context = wd["workflow_context"]
+        workflow._is_complete = wd["is_complete"]
+        workflow._save()
+        workflow._dirty = False
+
+        cme = self.chat_session.cme_workflow
+        cd = snapshot["cme_dict"]
+        cme._context = cd["workflow_context"]
+        cme._save()
+        cme._dirty = False
+
+        orig_len = snapshot["conversation_history_len"]
+        # Create a new History instance instead of modifying frozen messages
+        import dspy
+        self.chat_session._conversation_history = dspy.History(
+            messages=self.chat_session._conversation_history.messages[:orig_len]
+        )
+
+        _reset_action_log()
+
+    # ------------------------------------------------------------------
+    # Trajectory helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_exec_steps(trajectory: dict) -> list[dict]:
+        """
+        Extract execute_workflow_query steps from a ReAct trajectory.
+
+        Returns a list of dicts with keys: step_idx, thought, tool_name, tool_args, observation.
+        Only includes steps where tool_name == "execute_workflow_query".
+        """
+        steps = []
+        idx = 0
+        while True:
+            tool_name_key = f"tool_name_{idx}"
+            if tool_name_key not in trajectory:
+                break
+            tool_name = trajectory[tool_name_key]
+            if tool_name == "execute_workflow_query":
+                steps.append({
+                    "step_idx": idx,
+                    "thought": trajectory.get(f"thought_{idx}", ""),
+                    "tool_name": tool_name,
+                    "tool_args": trajectory.get(f"tool_args_{idx}", {}),
+                    "observation": trajectory.get(f"observation_{idx}", ""),
+                })
+            idx += 1
+        return steps
+
+    @staticmethod
+    def _format_trajectory_for_llm(trajectory: dict) -> str:
+        """Format a ReAct trajectory dict into a readable string for the insight LLM."""
+        lines = []
+        idx = 0
+        while True:
+            thought_key = f"thought_{idx}"
+            if thought_key not in trajectory and f"tool_name_{idx}" not in trajectory:
+                break
+            if thought_key in trajectory:
+                lines.append(f"[Step {idx}] Thought: {trajectory[thought_key]}")
+            if f"tool_name_{idx}" in trajectory:
+                lines.append(f"[Step {idx}] Tool: {trajectory[f'tool_name_{idx}']}")
+            if f"tool_args_{idx}" in trajectory:
+                args = trajectory[f"tool_args_{idx}"]
+                lines.append(f"[Step {idx}] Args: {json.dumps(args, default=str)}")
+            if f"observation_{idx}" in trajectory:
+                obs = str(trajectory[f"observation_{idx}"])
+                # Truncate very long observations
+                if len(obs) > 500:
+                    obs = f"{obs[:500]}... [truncated]"
+                lines.append(f"[Step {idx}] Observation: {obs}")
+            lines.append("")
+            idx += 1
+
+        # Include conversation history context if present
+        if "observation_about_conversation_history" in trajectory:
+            lines.insert(0, f"[Context] Conversation history: {trajectory['observation_about_conversation_history']}\n")
+
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Trajectory comparison (uses action.jsonl records)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _action_signature(action: dict) -> tuple[str, str]:
+        """Return (command_name, sorted-params-json) as a comparable unit."""
+        cmd = action.get("command_name", "")
+        params = action.get("parameters", {})
+        return (cmd, json.dumps(params, sort_keys=True, default=str))
+
+    @staticmethod
+    def _format_action(action: dict) -> str:
+        """Human-readable representation of an action (command + params)."""
+        cmd = action.get("command_name", "")
+        params = action.get("parameters", {})
+        return f"{cmd}({json.dumps(params, default=str)})" if params else cmd
+
+    def compare_trajectories(
+        self,
+        teacher_actions: list[dict],
+        student_actions: list[dict],
+    ) -> tuple[bool, str]:
+        """
+        Compare teacher and student action lists from action.jsonl.
+
+        Each action is treated as a (command_name, parameters) unit.
+        Instead of strict step-by-step ordering, this produces a human-readable
+        summary of all differences and lets the insight extraction LLM judge
+        whether those differences constitute genuine mistakes or are justified
+        by multi-turn conversation context divergence.
+
+        Returns:
+            (has_divergence: bool, divergence_summary: str)
+            divergence_summary is empty when has_divergence is False.
+        """
+        # Filter out internal error correction actions (abort commands from loop detection)
+        def is_valid_action(a: dict) -> bool:
+            cmd = a.get("command_name", "")
+            # Exclude ErrorCorrection/abort and ask_user records (which have agent_query key)
+            return cmd and not cmd.startswith("ErrorCorrection/") and "agent_query" not in a
+
+        teacher_actions = [a for a in teacher_actions if is_valid_action(a)]
+        student_actions = [a for a in student_actions if is_valid_action(a)]
+
+        teacher_sigs = [self._action_signature(a) for a in teacher_actions]
+        student_sigs = [self._action_signature(a) for a in student_actions]
+
+        # Fast path: identical sequences (same actions, same order)
+        if teacher_sigs == student_sigs:
+            return False, ""
+
+        differences: list[str] = []
+
+        # Compare actions as (command_name, params) units
+        teacher_sig_set = set(teacher_sigs)
+        student_sig_set = set(student_sigs)
+
+        only_teacher = teacher_sig_set - student_sig_set
+        only_student = student_sig_set - teacher_sig_set
+
+        if only_teacher:
+            only_teacher_strs = [
+                self._format_action(a)
+                for a in teacher_actions
+                if self._action_signature(a) in only_teacher
+            ]
+            differences.append(
+                f"Actions executed only by teacher: {only_teacher_strs}"
+            )
+
+        if only_student:
+            only_student_strs = [
+                self._format_action(a)
+                for a in student_actions
+                if self._action_signature(a) in only_student
+            ]
+            differences.append(
+                f"Actions executed only by student: {only_student_strs}"
+            )
+
+        # Check ordering of shared actions (only if there are actual shared actions)
+        shared_teacher_sigs = [s for s in teacher_sigs if s in student_sig_set]
+        shared_student_sigs = [s for s in student_sigs if s in teacher_sig_set]
+
+        # Only report ordering differences if there are meaningful shared actions
+        if shared_teacher_sigs and shared_student_sigs and shared_teacher_sigs != shared_student_sigs:
+            teacher_order = [
+                self._format_action(a)
+                for a in teacher_actions
+                if self._action_signature(a) in student_sig_set
+            ]
+            student_order = [
+                self._format_action(a)
+                for a in student_actions
+                if self._action_signature(a) in teacher_sig_set
+            ]
+            # Only add if we actually have formatted actions (not empty strings)
+            if teacher_order and student_order and any(teacher_order) and any(student_order):
+                differences.append(
+                    f"Different execution order — "
+                    f"teacher: {teacher_order}, student: {student_order}"
+                )
+
+        if not differences:
+            # Sequences differ in some way we didn't classify—still flag it
+            differences.append(
+                "Action sequences differ (unclassified difference)"
+            )
+
+        return True, "\n".join(differences)
+
+    # ------------------------------------------------------------------
+    # Planning trace helpers
+    # ------------------------------------------------------------------
+
+    def compare_planning_traces(
+        self,
+        teacher_steps: list[PlanningStep],
+        student_steps: list[PlanningStep],
+    ) -> tuple[bool, str]:
+        """
+        Compare teacher and student planning traces.
+
+        Returns:
+            (has_divergence: bool, divergence_summary: str)
+        """
+        if not teacher_steps and not student_steps:
+            return False, ""
+
+        differences = []
+
+        # Compare plans at each step
+        for i in range(max(len(teacher_steps), len(student_steps))):
+            t_plan = teacher_steps[i].generated_plan if i < len(teacher_steps) else []
+            s_plan = student_steps[i].generated_plan if i < len(student_steps) else []
+
+            # Normalize for comparison
+            t_normalized = [p.lower().strip() for p in t_plan]
+            s_normalized = [p.lower().strip() for p in s_plan]
+
+            if t_normalized != s_normalized:
+                differences.append(
+                    f"Step {i}: Teacher planned {t_plan}, Student planned {s_plan}"
+                )
+
+        return (True, "\n".join(differences)) if differences else (False, "")
+
+    @staticmethod
+    def _format_planning_traces_for_llm(steps: list[PlanningStep]) -> str:
+        """Format planning steps into readable string for insight LLM."""
+        lines = []
+        for step in steps:
+            lines.append(f"[Step {step.step_number}] Query: {step.user_query}")
+            if step.reasoning:
+                lines.append(f"[Step {step.step_number}] Reasoning: {step.reasoning}")
+            lines.extend((f"[Step {step.step_number}] Plan: {step.generated_plan}", ""))
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Agent run helper
+    # ------------------------------------------------------------------
+
+    def _run_agent_pass(
+        self,
+        message: str,
+        agent_lm_role: str,
+        agent_api_key_role: str,
+        planner_lm_role: str,
+        planner_api_key_role: str,
+    ) -> tuple[fastworkflow.CommandOutput, dict, list[dict], list[PlanningStep]]:
+        """
+        Run a full agent pass with the specified LLMs for planner and agent.
+
+        Returns:
+            (command_output, trajectory_dict, actions_from_jsonl, planning_steps)
+            actions_from_jsonl: list of dicts from action.jsonl with keys
+                command, command_name, parameters, response
+            planning_steps: list of PlanningStep objects capturing planning decisions
+        """
+        # Clean prior action log
+        _reset_action_log()
+
+        # Store raw message in workflow context (mirrors _process_agent_message)
+        self.chat_session.get_active_workflow().context["raw_user_message"] = message
+
+        # Create agent with the specified LLM
+        from fastworkflow.workflow_agent import (
+            initialize_workflow_tool_agent,
+            build_query_with_next_steps,
+            _what_can_i_do,
+        )
+
+        # Load execution insights for the agent
+        execution_insights = getattr(
+            self.chat_session, "_execution_insights", None
+        )
+
+        agent = initialize_workflow_tool_agent(
+            self.chat_session,
+            execution_insights=execution_insights,
+        )
+
+        # Temporarily install this agent
+        original_agent = self.chat_session._workflow_tool_agent
+        self.chat_session._workflow_tool_agent = agent
+
+        try:
+            refined_message = self.chat_session._refine_user_query(
+                message, self.chat_session.conversation_history
+            )
+
+            # Get planning insights for injection into planner prompt
+            planning_insights = getattr(self.chat_session, '_planning_insights', None)
+
+            # Set up planner LM for this pass
+            planner_lm = dspy_utils.get_lm(planner_lm_role, planner_api_key_role)
+
+            # Store planner_lm on the session so it can be used for replanning
+            self.chat_session._current_planner_lm = planner_lm
+
+            # Initialize capture list on the session to capture ALL plans
+            # (initial + replanning during agent execution)
+            self.chat_session._planning_steps_capture = []
+
+            # Build initial query with next steps using the PLANNER LLM
+            # The hook in build_query_with_next_steps will auto-capture the plan
+            command_info = build_query_with_next_steps(
+                refined_message, self.chat_session, planning_insights=planning_insights, planner_lm=planner_lm
+            )
+
+            # Get available commands for current context
+            available_commands = _what_can_i_do(self.chat_session)
+
+            # Run the agent with the specified AGENT LLM
+            agent_lm = dspy_utils.get_lm(agent_lm_role, agent_api_key_role)
+            agent_adapter = CommandsSystemPreludeAdapter()
+
+            from dspy.utils.exceptions import AdapterParseError
+
+            max_retries = 2
+            agent_result = None
+            for attempt in range(max_retries):
+                try:
+                    with dspy.context(lm=agent_lm, adapter=agent_adapter):
+                        agent_result = agent(
+                            user_query=command_info,
+                            available_commands=available_commands,
+                        )
+                    break
+                except AdapterParseError:
+                    if attempt == max_retries - 1:
+                        raise
+
+            # Extract result text
+            result_text = (
+                agent_result.final_answer
+                if hasattr(agent_result, "final_answer")
+                else str(agent_result)
+            )
+
+            # Build CommandOutput
+            command_response = fastworkflow.CommandResponse(response=result_text)
+            command_output = fastworkflow.CommandOutput(
+                command_responses=[command_response]
+            )
+            command_output.workflow_name = (
+                self.chat_session.get_active_workflow().folderpath.split("/")[-1]
+            )
+
+            # Read actions from the action log (actual resolved command_name + parameters)
+            actions = []
+            if os.path.exists(_ACTION_LOG_FILE):
+                with open(_ACTION_LOG_FILE, "r", encoding="utf-8") as f:
+                    for line in f:
+                        if line := line.strip():
+                            try:
+                                actions.append(json.loads(line))
+                            except json.JSONDecodeError:
+                                continue
+
+            # Capture the full ReAct trajectory
+            trajectory = dict(agent.current_trajectory)
+
+            # Add conversation summary to history (mirrors _process_agent_message)
+            conversation_summary = message
+            conversation_traces = None
+            if actions:
+                conversation_summary, conversation_traces = (
+                    self.chat_session._extract_conversation_summary(
+                        message, actions, result_text
+                    )
+                )
+
+            self.chat_session.conversation_history.messages.append(
+                {
+                    "conversation summary": conversation_summary,
+                    "conversation_traces": conversation_traces,
+                    "feedback": None,
+                }
+            )
+
+            # Flush workflow state
+            if workflow := self.chat_session.get_active_workflow():
+                workflow.flush()
+
+            # Collect all captured planning steps (initial + replanning)
+            planning_steps = list(
+                getattr(self.chat_session, '_planning_steps_capture', [])
+            )
+
+            return command_output, trajectory, actions, planning_steps
+
+        finally:
+            # Restore original agent and clean up distillation-specific attributes
+            self.chat_session._workflow_tool_agent = original_agent
+            if hasattr(self.chat_session, '_current_planner_lm'):
+                delattr(self.chat_session, '_current_planner_lm')
+            if hasattr(self.chat_session, '_planning_steps_capture'):
+                delattr(self.chat_session, '_planning_steps_capture')
+
+    # ------------------------------------------------------------------
+    # Insight extraction
+    # ------------------------------------------------------------------
+
+    def extract_insights(
+        self,
+        teacher_traj: dict,
+        student_traj: dict,
+        divergence_summary: str,
+        user_query: str,
+    ) -> list[str]:
+        """
+        Use LLM_DISTILLATION to analyze the trajectory delta and extract insights.
+
+        Uses the full ReAct trajectories (which include conversation context via
+        observation_about_conversation_history and ask_user observations).
+
+        The divergence_summary describes concrete action-level differences;
+        the LLM uses the full trajectories to judge whether differences are
+        genuine mistakes or context-justified.
+
+        Returns a list of insight strings, or empty list if no genuine mistakes.
+        """
+        # Load existing insights for dedup
+        from fastworkflow.utils.insights_loader import load_workflow_insights
+
+        workflow = self.chat_session.get_active_workflow()
+        existing_insights = (
+            load_workflow_insights(workflow.folderpath, "execution_agent") or ""
+        )
+
+        # Format trajectories for the LLM
+        teacher_formatted = self._format_trajectory_for_llm(teacher_traj)
+        student_formatted = self._format_trajectory_for_llm(student_traj)
+
+        lm = dspy_utils.get_lm("LLM_DISTILLATION", "LITELLM_API_KEY_DISTILLATION")
+
+        with dspy.context(lm=lm):
+            extractor = dspy.ChainOfThought(InsightExtractionSignature)
+            result = extractor(
+                user_query=user_query,
+                teacher_trajectory=teacher_formatted,
+                student_trajectory=student_formatted,
+                divergence_summary=divergence_summary,
+                existing_insights=existing_insights,
+            )
+
+        raw_insights = (getattr(result, "insights", None) or "").strip()
+
+        # Treat "EMPTY" or empty string as no insights
+        if not raw_insights or raw_insights.upper() == "EMPTY":
+            return []
+
+        # Parse bullet points: each line starting with "- "
+        insights = []
+        for line in raw_insights.split("\n"):
+            line = line.strip()
+            if line.startswith("- "):
+                insights.append(line[2:].strip())
+            elif line and not line.startswith("#"):
+                # Accept non-prefixed lines as insights too
+                insights.append(line)
+
+        return [i for i in insights if i]
+
+    # ------------------------------------------------------------------
+    # Insight persistence
+    # ------------------------------------------------------------------
+
+    def _insights_dir(self) -> Path:
+        """Return (creating if needed) the workflow's Insights directory."""
+        workflow = self.chat_session.get_active_workflow()
+        workflow_name = Path(workflow.folderpath).name
+        insights_dir = Path(workflow.folderpath) / "Insights" / workflow_name
+        insights_dir.mkdir(parents=True, exist_ok=True)
+        return insights_dir
+
+    @staticmethod
+    def _append_numbered_insights(
+        insights: list[str],
+        insights_file: Path,
+        header: str,
+        number_pattern: str,
+        entry_format: str,
+    ) -> None:
+        """
+        Append ``insights`` to ``insights_file`` as a numbered list, continuing
+        the numbering already present in the file.
+
+        ``number_pattern`` is a regex (with one capturing group for the number)
+        used to find existing entries; ``entry_format`` is a format string taking
+        ``num`` and ``insight``. The two MUST correspond so the numbering the file
+        is read with matches the numbering it is written with.
+        """
+        if insights_file.exists():
+            content = insights_file.read_text(encoding="utf-8")
+            numbers = re.findall(number_pattern, content, re.MULTILINE)
+            next_num = max(int(n) for n in numbers) + 1 if numbers else 1
+        else:
+            insights_file.write_text(header, encoding="utf-8")
+            next_num = 1
+
+        with open(insights_file, "a", encoding="utf-8") as f:
+            for insight in insights:
+                f.write(entry_format.format(num=next_num, insight=insight))
+                next_num += 1
+
+    def append_insights(self, insights: list[str]):
+        """Append new insights to execution_agent_anti_patterns.md."""
+        if not insights:
+            return
+
+        insights_file = self._insights_dir() / "execution_agent_anti_patterns.md"
+        self._append_numbered_insights(
+            insights,
+            insights_file,
+            header=(
+                "# Execution Agent Anti-Patterns\n\n"
+                "Critical mistakes to avoid when executing workflows, "
+                "derived from distillation.\n\n"
+            ),
+            number_pattern=r"^(\d+)\.\s",
+            entry_format="{num}. {insight}\n",
+        )
+
+        self.execution_insights_extracted += len(insights)
+
+    # ------------------------------------------------------------------
+    # Planning insight extraction
+    # ------------------------------------------------------------------
+
+    def extract_planning_insights(
+        self,
+        teacher_steps: list[PlanningStep],
+        student_steps: list[PlanningStep],
+        divergence_summary: str,
+        user_query: str,
+        teacher_actions: list[dict],
+        student_actions: list[dict],
+    ) -> list[str]:
+        """Extract prescriptive planning rules using LLM_DISTILLATION.
+
+        Uses both planning traces and executed actions to give the insight
+        extraction LLM full context for judging plan quality.
+        """
+        # Load existing planning insights for dedup
+        from fastworkflow.utils.insights_loader import load_workflow_insights
+
+        workflow = self.chat_session.get_active_workflow()
+        existing_insights = (
+            load_workflow_insights(workflow.folderpath, "planning_agent") or ""
+        )
+
+        # Format planning traces
+        teacher_plan_str = self._format_planning_traces_for_llm(teacher_steps)
+        student_plan_str = self._format_planning_traces_for_llm(student_steps)
+
+        # Format executed actions for context
+        teacher_actions_str = "\n".join(
+            self._format_action(a) for a in teacher_actions
+        ) or "(no actions executed)"
+        student_actions_str = "\n".join(
+            self._format_action(a) for a in student_actions
+        ) or "(no actions executed)"
+
+        lm = dspy_utils.get_lm("LLM_DISTILLATION", "LITELLM_API_KEY_DISTILLATION")
+
+        with dspy.context(lm=lm):
+            extractor = dspy.ChainOfThought(PlanningInsightExtractionSignature)
+            result = extractor(
+                user_query=user_query,
+                teacher_plan=teacher_plan_str,
+                student_plan=student_plan_str,
+                divergence_summary=divergence_summary,
+                teacher_actions=teacher_actions_str,
+                student_actions=student_actions_str,
+                existing_insights=existing_insights,
+            )
+
+        raw_insights = (getattr(result, "insights", None) or "").strip()
+        if not raw_insights or raw_insights.upper() == "EMPTY":
+            return []
+
+        # Parse numbered rules (1. rule, 2. rule, etc.)
+        insights = []
+        for line in raw_insights.split("\n"):
+            line = line.strip()
+            if line and line[0].isdigit() and "." in line[:3]:
+                if rule_text := line.split(".", 1)[1].strip():
+                    insights.append(rule_text)
+
+        return insights
+
+    def append_planning_insights(self, insights: list[str]):
+        """Append new planning insights to planning_agent_insights.md."""
+        if not insights:
+            return
+
+        insights_file = self._insights_dir() / "planning_agent_insights.md"
+        self._append_numbered_insights(
+            insights,
+            insights_file,
+            header=(
+                "# Planning Agent Insights\n\n"
+                "Key insights for planning workflow execution strategies, "
+                "derived from distillation training.\n\n"
+            ),
+            number_pattern=r"^## (\d+)\.",
+            entry_format="## {num}. {insight}\n\n",
+        )
+
+        self.planning_insights_extracted += len(insights)
+
+
+# ------------------------------------------------------------------
+# Top-level orchestrator
+# ------------------------------------------------------------------
+
+
+def distill_message(
+    chat_session: "fastworkflow.WorkflowExecutionContext", message: str
+) -> DistillationResult:
+    """
+    Run teacher and student agents, extract BOTH planning and execution insights.
+
+    Flow:
+    1. Snapshot state
+    2. Run teacher - capture planning traces + actions
+    3. Save teacher's final state
+    4. Restore pre-teacher state
+    5. Run student - capture planning traces + actions
+    6a. Compare planning traces → extract planning insights
+    6b. Compare executed actions → extract execution insights
+    7. On divergence: restore teacher's state; else keep student's
+    8. Return teacher's output
+    """
+    ds = DistillationSession(chat_session)
+
+    teacher_model = fastworkflow.get_env_var("LLM_TEACHER_AGENT") or "LLM_TEACHER_AGENT"
+    student_model = fastworkflow.get_env_var("LLM_STUDENT_AGENT") or "LLM_STUDENT_AGENT"
+
+    # 1. Snapshot initial state
+    initial_snapshot = ds.snapshot_workflow_state()
+
+    # 2. Run teacher (returns planning_steps too now)
+    _announce("TEACHER pass", teacher_model, style="bold magenta")
+    teacher_output, teacher_traj, teacher_actions, teacher_plans = ds._run_agent_pass(
+        message,
+        agent_lm_role="LLM_TEACHER_AGENT",
+        agent_api_key_role="LITELLM_API_KEY_TEACHER_AGENT",
+        planner_lm_role="LLM_TEACHER_PLANNER",
+        planner_api_key_role="LITELLM_API_KEY_TEACHER_PLANNER",
+    )
+
+    # 3. Save teacher's final state
+    teacher_final_state = ds.snapshot_workflow_state()
+
+    # 4. Restore initial state for student run
+    ds.restore_workflow_state(initial_snapshot)
+
+    # 5. Run student
+    _announce("STUDENT pass", student_model, style="bold cyan")
+    try:
+        student_output, student_traj, student_actions, student_plans = ds._run_agent_pass(
+            message,
+            agent_lm_role="LLM_STUDENT_AGENT",
+            agent_api_key_role="LITELLM_API_KEY_STUDENT_AGENT",
+            planner_lm_role="LLM_STUDENT_PLANNER",
+            planner_api_key_role="LITELLM_API_KEY_STUDENT_PLANNER",
+        )
+    except Exception as e:
+        logger.warning(f"Distillation: student agent failed: {e}")
+        ds.restore_workflow_state(teacher_final_state)
+        return DistillationResult(command_output=teacher_output)
+
+    any_divergence = False
+
+    # 6a. Compare and extract PLANNING insights
+    planning_diverged, planning_summary = ds.compare_planning_traces(
+        teacher_plans, student_plans
+    )
+    if planning_diverged:
+        planning_insights = ds.extract_planning_insights(
+            teacher_plans, student_plans,
+            planning_summary, message,
+            teacher_actions, student_actions,
+        )
+        if planning_insights:
+            ds.append_planning_insights(planning_insights)
+        any_divergence = True
+
+    # 6b. Compare and extract EXECUTION insights (existing logic)
+    exec_diverged, exec_summary = ds.compare_trajectories(
+        teacher_actions, student_actions
+    )
+    if exec_diverged:
+        exec_insights = ds.extract_insights(
+            teacher_traj, student_traj,
+            exec_summary, message
+        )
+        if exec_insights:
+            ds.append_insights(exec_insights)
+        any_divergence = True
+
+    # 7. State restoration
+    if any_divergence:
+        ds.restore_workflow_state(teacher_final_state)
+    # else: keep student's state (equivalent to teacher's)
+
+    total_insights = ds.planning_insights_extracted + ds.execution_insights_extracted
+    if any_divergence:
+        _announce(
+            "DISTILLATION: divergence found",
+            f"{ds.planning_insights_extracted} planning + "
+            f"{ds.execution_insights_extracted} execution insight(s) extracted",
+            style="bold yellow",
+        )
+    else:
+        _announce(
+            "DISTILLATION: no divergence",
+            "student matched teacher — no insights extracted",
+            style="green",
+        )
+
+    return DistillationResult(
+        command_output=teacher_output,
+        planning_insights_extracted=ds.planning_insights_extracted,
+        execution_insights_extracted=ds.execution_insights_extracted,
+    )

--- a/fastworkflow/distillation.py
+++ b/fastworkflow/distillation.py
@@ -21,14 +21,12 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import dspy
 
 import fastworkflow
 from fastworkflow.utils.logging import logger
 from fastworkflow.utils import dspy_utils
-from fastworkflow.utils.chat_adapter import CommandsSystemPreludeAdapter
 
 # Per-turn log of executed actions, written by the workflow agent and read back
 # here to compare teacher vs. student trajectories.
@@ -537,25 +535,16 @@ class DistillationSession:
             # Get available commands for current context
             available_commands = _what_can_i_do(self.chat_session)
 
-            # Run the agent with the specified AGENT LLM
+            # Run the agent with the specified AGENT LLM, reusing the WEC's shared
+            # agent-invocation contract (dspy.context + AdapterParseError retry).
             agent_lm = dspy_utils.get_lm(agent_lm_role, agent_api_key_role)
-            agent_adapter = CommandsSystemPreludeAdapter()
-
-            from dspy.utils.exceptions import AdapterParseError
-
-            max_retries = 2
-            agent_result = None
-            for attempt in range(max_retries):
-                try:
-                    with dspy.context(lm=agent_lm, adapter=agent_adapter):
-                        agent_result = agent(
-                            user_query=command_info,
-                            available_commands=available_commands,
-                        )
-                    break
-                except AdapterParseError:
-                    if attempt == max_retries - 1:
-                        raise
+            agent_result = self.chat_session._call_agent_with_retry(
+                lambda: agent(
+                    user_query=command_info,
+                    available_commands=available_commands,
+                ),
+                lm=agent_lm,
+            )
 
             # Extract result text
             result_text = (
@@ -587,23 +576,7 @@ class DistillationSession:
             # Capture the full ReAct trajectory
             trajectory = dict(agent.current_trajectory)
 
-            # Add conversation summary to history (mirrors _process_agent_message)
-            conversation_summary = message
-            conversation_traces = None
-            if actions:
-                conversation_summary, conversation_traces = (
-                    self.chat_session._extract_conversation_summary(
-                        message, actions, result_text
-                    )
-                )
-
-            self.chat_session.conversation_history.messages.append(
-                {
-                    "conversation summary": conversation_summary,
-                    "conversation_traces": conversation_traces,
-                    "feedback": None,
-                }
-            )
+            self.chat_session.summarize_and_record_turn(message, actions, result_text)
 
             # Flush workflow state
             if workflow := self.chat_session.get_active_workflow():
@@ -933,7 +906,6 @@ def distill_message(
         ds.restore_workflow_state(teacher_final_state)
     # else: keep student's state (equivalent to teacher's)
 
-    total_insights = ds.planning_insights_extracted + ds.execution_insights_extracted
     if any_divergence:
         _announce(
             "DISTILLATION: divergence found",

--- a/fastworkflow/run/__main__.py
+++ b/fastworkflow/run/__main__.py
@@ -183,7 +183,10 @@ def run_main(args):
             context_dict = json.load(file)
 
     run_as_agent = not args.assistant
-    fastworkflow.chat_session = fastworkflow.ChatSession(run_as_agent=run_as_agent)
+    fastworkflow.chat_session = fastworkflow.ChatSession(
+        run_as_agent=run_as_agent,
+        generate_insights=getattr(args, "generate_insights", False),
+    )
     
     # Start the workflow within the chat session
     fastworkflow.chat_session.start_workflow(
@@ -220,6 +223,11 @@ def run_main(args):
         with patch_stdout():
             user_command = prompt_session.prompt()
         if user_command.startswith("//exit"):
+            if getattr(args, "generate_insights", False):
+                count = getattr(fastworkflow.chat_session, "_distillation_insights_count", 0)
+                console.print(
+                    f"\n[bold cyan]Insights generation complete. New insights extracted: {count}[/bold cyan]"
+                )
             break
         if user_command.startswith("//new"):
             fastworkflow.chat_session.clear_conversation_history()
@@ -291,6 +299,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--assistant", action="store_true", default=False,
         help="Run in assistant (non-agentic) mode. Default is agentic mode.",
+    )
+    parser.add_argument(
+        "--generate_insights", action="store_true", default=False,
+        help="Enable insights-distillation mode: compare teacher and student agents, extract planning and execution insights on divergence.",
     )
     args = parser.parse_args()
     run_main(args)

--- a/fastworkflow/utils/insights_loader.py
+++ b/fastworkflow/utils/insights_loader.py
@@ -1,0 +1,67 @@
+"""
+Utility module for loading workflow-specific insights for knowledge distillation.
+
+This module provides functionality to load planning and execution insights from
+workflow directories, enabling the integration of learned patterns and anti-patterns
+into agent prompts.
+"""
+
+from pathlib import Path
+from typing import Optional
+from fastworkflow.utils.logging import logger
+
+
+def load_workflow_insights(workflow_folderpath: str, insight_type: str) -> Optional[str]:
+    """
+    Load workflow-specific insights for knowledge distillation.
+
+    This function looks for insights files in the workflow's Insights directory,
+    following the convention: workflow_folderpath/Insights/<workflow_name>/<insight_file>
+
+    Args:
+        workflow_folderpath: Absolute path to workflow directory
+        insight_type: Type of insights to load. Supported values:
+            - 'planning_agent': Planning strategies and patterns
+            - 'execution_agent': Execution anti-patterns and rules
+
+    Returns:
+        Insights content as string if found, None otherwise
+
+    Example:
+        >>> insights = load_workflow_insights('/path/to/my_workflow', 'planning_agent')
+        >>> if insights:
+        ...     print(f"Loaded {len(insights)} characters of insights")
+    """
+    # Extract workflow name from folderpath (last component)
+    workflow_name = Path(workflow_folderpath).name
+
+    # Build path: workflow_folderpath/Insights/<workflow_name>/
+    insights_dir = Path(workflow_folderpath) / "Insights" / workflow_name
+
+    if not insights_dir.exists():
+        logger.debug(f"No Insights directory found at {insights_dir}")
+        return None
+
+    # Map insight type to filename
+    filename_map = {
+        "planning_agent": "planning_agent_insights.md",
+        "execution_agent": "execution_agent_anti_patterns.md"
+    }
+
+    if insight_type not in filename_map:
+        logger.warning(f"Unknown insight type: {insight_type}. Supported types: {list(filename_map.keys())}")
+        return None
+
+    insight_file = insights_dir / filename_map[insight_type]
+
+    if not insight_file.exists():
+        logger.debug(f"Insights file not found: {insight_file}")
+        return None
+
+    try:
+        content = insight_file.read_text(encoding='utf-8')
+        logger.info(f"Loaded {insight_type} insights from {insight_file} ({len(content)} characters)")
+        return content
+    except Exception as e:
+        logger.error(f"Error reading insights file {insight_file}: {e}")
+        return None

--- a/fastworkflow/utils/react.py
+++ b/fastworkflow/utils/react.py
@@ -29,7 +29,8 @@ class AskUserSuspend(BaseException):
 
 
 class fastWorkflowReAct(Module):
-    def __init__(self, signature: type["Signature"], tools: list[Callable], max_iters: int = 10):
+    def __init__(self, signature: type["Signature"], tools: list[Callable], max_iters: int = 10,
+                 on_step_complete: Callable[[int, dict], bool] | None = None):
         """
         ReAct stands for "Reasoning and Acting," a popular paradigm for building tool-using agents.
         In this approach, the language model is iteratively provided with a list of tools and has
@@ -108,6 +109,7 @@ class fastWorkflowReAct(Module):
 
         self.inputs = {}
         self.current_trajectory = {}
+        self._on_step_complete = on_step_complete
         self._suspended: dict[str, Any] | None = None
         # True when the most recent _run_loop ended because max_iters was
         # reached without the agent selecting the `finish` tool.
@@ -235,6 +237,20 @@ class fastWorkflowReAct(Module):
                     break
                 continue
 
+            # Guard against an invalid/empty prediction (e.g. the LLM returned
+            # nothing parseable). Return a graceful fallback in the same shape as
+            # the normal return (a dspy.Prediction exposing .final_answer) instead
+            # of crashing.
+            if pred is None or not hasattr(pred, "next_thought"):
+                logger.warning(
+                    f"ReAct iteration {idx}: LLM returned None or invalid prediction. "
+                    "Returning fallback answer."
+                )
+                return dspy.Prediction(
+                    final_answer="I apologize, but I encountered an error processing your "
+                    "request. Could you please rephrase or provide more details?"
+                )
+
             trajectory[f"thought_{idx}"] = pred.next_thought
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
@@ -264,6 +280,16 @@ class fastWorkflowReAct(Module):
                 trajectory[f"observation_{idx}"] = (
                     f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
                 )
+
+            # Step-completion callback for distillation: lets external code inspect
+            # each completed step and stop execution early (e.g. on trajectory
+            # divergence). Placed AFTER the AskUserSuspend catch so it can never
+            # swallow a suspension, and it does not touch _suspended state.
+            # getattr guard: resume() may run on an instance built via __new__
+            # (test helpers) that never set this attribute.
+            on_step_complete = getattr(self, "_on_step_complete", None)
+            if on_step_complete and not on_step_complete(idx, trajectory):
+                break
 
             if pred.next_tool_name == "finish":
                 break

--- a/fastworkflow/utils/react.py
+++ b/fastworkflow/utils/react.py
@@ -152,6 +152,13 @@ class fastWorkflowReAct(Module):
         self.inputs = input_args
         self.clear_suspension()
 
+        # Reset the full-trajectory mirror at the start of each logical turn.
+        # resume() must NOT reset it, so a suspended->resumed turn accumulates one
+        # coherent trajectory. current_trajectory is a SEPARATE object from the
+        # working `trajectory` below (which is what gets stashed in _suspended),
+        # so mirroring into it never corrupts suspend/resume bookkeeping.
+        self.current_trajectory = {}
+
         trajectory: dict[str, Any] = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         idx = 0
@@ -182,6 +189,11 @@ class fastWorkflowReAct(Module):
         max_iters = stash["max_iters"]
 
         trajectory[f"observation_{idx}"] = observation
+        # Mirror the resumed observation (the user's ask_user answer) into
+        # current_trajectory. Without this the highest-value context — what the
+        # user said in response to the clarification — would be missing from the
+        # trajectory the planner and distillation see.
+        self.current_trajectory[f"observation_{idx}"] = observation
         idx += 1
         self.iteration_counter += 1
         self._suspended = None
@@ -219,18 +231,24 @@ class fastWorkflowReAct(Module):
                     self.react, trajectory, **input_args
                 )
             except ValueError as err:
-                trajectory[f"observation_{idx}"] = (
+                invalid_tool_obs = (
                     f"Agent failed to select a valid tool: {_fmt_exc(err)}"
                 )
+                trajectory[f"observation_{idx}"] = invalid_tool_obs
+                self.current_trajectory[f"observation_{idx}"] = invalid_tool_obs
                 idx += 1
-                trajectory[f"thought_{idx}"] = (
+                recovery_thought = (
                     "To execute a command, I should use the execute_workflow_query tool"
                 )
-                trajectory[f"observation_{idx}"] = (
+                recovery_obs = (
                     "Use the execute_workflow_query tool with a single argument called "
                     "'command' formatted as plain text using the command name and "
                     "parameter values"
                 )
+                trajectory[f"thought_{idx}"] = recovery_thought
+                trajectory[f"observation_{idx}"] = recovery_obs
+                self.current_trajectory[f"thought_{idx}"] = recovery_thought
+                self.current_trajectory[f"observation_{idx}"] = recovery_obs
                 idx += 1
                 exception_count += 1
                 if exception_count > 2:
@@ -255,14 +273,20 @@ class fastWorkflowReAct(Module):
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
+            # Mirror the full step into current_trajectory (consumed by the planner
+            # for replanning and by distillation as the agent trajectory). Keep the
+            # legacy action_{idx} entry too for any consumer that still reads it.
+            self.current_trajectory[f"thought_{idx}"] = pred.next_thought
+            self.current_trajectory[f"tool_name_{idx}"] = pred.next_tool_name
+            self.current_trajectory[f"tool_args_{idx}"] = pred.next_tool_args
             self.current_trajectory[f"action_{idx}"] = (
                 f"{pred.next_tool_name}: {pred.next_tool_args}"
             )
 
             try:
-                trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](
-                    **pred.next_tool_args
-                )
+                observation = self.tools[pred.next_tool_name](**pred.next_tool_args)
+                trajectory[f"observation_{idx}"] = observation
+                self.current_trajectory[f"observation_{idx}"] = observation
             except AskUserSuspend as err:
                 self._suspended = {
                     "trajectory": trajectory,
@@ -277,9 +301,11 @@ class fastWorkflowReAct(Module):
                     exhausted=False,
                 )
             except Exception as err:
-                trajectory[f"observation_{idx}"] = (
+                error_observation = (
                     f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
                 )
+                trajectory[f"observation_{idx}"] = error_observation
+                self.current_trajectory[f"observation_{idx}"] = error_observation
 
             # Step-completion callback for distillation: lets external code inspect
             # each completed step and stop execution early (e.g. on trajectory

--- a/fastworkflow/utils/react.py
+++ b/fastworkflow/utils/react.py
@@ -230,6 +230,8 @@ class fastWorkflowReAct(Module):
                 pred = self._call_with_potential_trajectory_truncation(
                     self.react, trajectory, **input_args
                 )
+                if pred is None:
+                    raise ValueError("Tool returned is None")
             except ValueError as err:
                 invalid_tool_obs = (
                     f"Agent failed to select a valid tool: {_fmt_exc(err)}"
@@ -238,12 +240,10 @@ class fastWorkflowReAct(Module):
                 self.current_trajectory[f"observation_{idx}"] = invalid_tool_obs
                 idx += 1
                 recovery_thought = (
-                    "To execute a command, I should use the execute_workflow_query tool"
+                    "To execute a command, I should use one of the available tools"
                 )
                 recovery_obs = (
-                    "Use the execute_workflow_query tool with a single argument called "
-                    "'command' formatted as plain text using the command name and "
-                    "parameter values"
+                    "Use the appropriate tool with proper arguments (correctly formatted)"
                 )
                 trajectory[f"thought_{idx}"] = recovery_thought
                 trajectory[f"observation_{idx}"] = recovery_obs
@@ -254,20 +254,6 @@ class fastWorkflowReAct(Module):
                 if exception_count > 2:
                     break
                 continue
-
-            # Guard against an invalid/empty prediction (e.g. the LLM returned
-            # nothing parseable). Return a graceful fallback in the same shape as
-            # the normal return (a dspy.Prediction exposing .final_answer) instead
-            # of crashing.
-            if pred is None or not hasattr(pred, "next_thought"):
-                logger.warning(
-                    f"ReAct iteration {idx}: LLM returned None or invalid prediction. "
-                    "Returning fallback answer."
-                )
-                return dspy.Prediction(
-                    final_answer="I apologize, but I encountered an error processing your "
-                    "request. Could you please rephrase or provide more details?"
-                )
 
             trajectory[f"thought_{idx}"] = pred.next_thought
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name

--- a/fastworkflow/utils/signatures.py
+++ b/fastworkflow/utils/signatures.py
@@ -3,7 +3,7 @@ import ast
 import dspy
 import os
 from contextlib import suppress
-from typing import Optional, Tuple, Union, Dict, Any, Type, List, get_args
+from typing import Optional, Tuple, Union, Dict, Any, Type, List, get_args, get_origin
 from enum import Enum
 from datetime import date
 import re
@@ -18,6 +18,7 @@ from fastworkflow import ModuleType
 from fastworkflow.utils.logging import logger
 from fastworkflow.model_pipeline_training import get_route_layer_filepath_model
 from fastworkflow.utils.fuzzy_match import find_best_matches
+from fastworkflow.utils import dspy_utils
 from fastworkflow.command_directory import CommandDirectory
 
 MISSING_INFORMATION_ERRMSG = None
@@ -217,7 +218,8 @@ Today's date is {today}.
             info_text += f". This field is {requirement_status}."
 
             if is_optional:
-                info_text += f" If not mentioned in the query, use: '{default_value or 'None'}'."
+                default_display = default_value if default_value is not None else 'None'
+                info_text += f" If not mentioned in the query, use: '{default_display}'."
             elif default_value is not None:
                 info_text += f" Default value: '{default_value}'."
 
@@ -252,7 +254,7 @@ Today's date is {today}.
             LLM_PARAM_EXTRACTION = fastworkflow.get_env_var("LLM_PARAM_EXTRACTION")
             LITELLM_API_KEY_PARAM_EXTRACTION = fastworkflow.get_env_var("LITELLM_API_KEY_PARAM_EXTRACTION")
 
-        lm = dspy.LM(LLM_PARAM_EXTRACTION, api_key=LITELLM_API_KEY_PARAM_EXTRACTION)
+        lm = dspy_utils.get_lm("LLM_PARAM_EXTRACTION", "LITELLM_API_KEY_PARAM_EXTRACTION")
         
         model_class = CommandParameters 
         if model_class is None:
@@ -462,7 +464,15 @@ Today's date is {today}.
                                 if isinstance(expected_type, type) and issubclass(expected_type, Enum):
                                     ok, enum_val = _try_coerce_enum(expected_type, val)
                                     return (ok, enum_val if ok else None)
-                                                            # Unknown: accept if already instance
+                                # Pydantic BaseModel: construct from dict
+                                if isinstance(expected_type, type) and issubclass(expected_type, BaseModel):
+                                    if isinstance(val, expected_type):
+                                        return True, val
+                                    if isinstance(val, dict):
+                                        with suppress(Exception):
+                                            return True, expected_type(**val)
+                                    return False, None
+                                # Unknown: accept if already instance
                                 return (True, val) if isinstance(val, expected_type) else (False, None)
 
                         def _try_coerce_list(list_type: Any, value: Any) -> Tuple[bool, Optional[list]]:
@@ -574,16 +584,35 @@ Today's date is {today}.
                 if is_optional:
                         is_required=False
 
+                # Check if this is a list field
+                is_list_field = False
+                check_type = field_info.annotation
+                check_origin = get_origin(check_type)
+                if check_origin is Union:
+                    check_args = get_args(check_type)
+                    non_none = [t for t in check_args if t is not type(None)]
+                    if non_none:
+                        check_type = non_none[0]
+                        check_origin = get_origin(check_type)
+                if check_origin in (list, List):
+                    is_list_field = True
+
                 # Only add to missing fields if it's required AND has no value
-                if is_required and \
-                                field_value in [
-                        NOT_FOUND, 
-                        None,
-                        INVALID_INT_VALUE,
-                        INVALID_FLOAT_VALUE
-                    ]:
-                    missing_fields.append(field_name)
-                    is_valid = False
+                # For list fields, empty list [] is considered missing
+                if is_required:
+                    is_missing = False
+                    if is_list_field:
+                        # For list fields, treat empty list as missing
+                        if field_value in [NOT_FOUND, None] or (isinstance(field_value, list) and len(field_value) == 0):
+                            is_missing = True
+                    else:
+                        # For non-list fields, use standard sentinel values
+                        if field_value in [NOT_FOUND, None, INVALID_INT_VALUE, INVALID_FLOAT_VALUE]:
+                            is_missing = True
+
+                    if is_missing:
+                        missing_fields.append(field_name)
+                        is_valid = False
 
         for field_name, field_info in type(cmd_parameters).model_fields.items():
             field_value = getattr(cmd_parameters, field_name, None)

--- a/fastworkflow/workflow_agent.py
+++ b/fastworkflow/workflow_agent.py
@@ -578,8 +578,7 @@ def build_query_with_next_steps(user_query: str,
         if not prediction.next_steps:
             return user_query
 
-        steps_formatted = " ".join(prediction.next_steps.split())
-
+        generated_plan = prediction.next_steps.split()
         # Capture the generated plan for distillation when a capture list is present
         # on the session (set only during a DistillationSession planning pass).
         planning_capture = getattr(chat_session_obj, '_planning_steps_capture', None)
@@ -588,10 +587,11 @@ def build_query_with_next_steps(user_query: str,
             planning_capture.append(PlanningStep(
                 step_number=len(planning_capture),
                 user_query=user_query,
-                generated_plan=steps_formatted,
+                generated_plan=generated_plan,
                 reasoning=getattr(prediction, 'reasoning', ''),
             ))
 
+        steps_formatted = " ".join(generated_plan)
         user_query_and_next_steps = f"{user_query}\n\nExecute these next steps:\n{steps_formatted}"
         return (
             f'User Query:\n{user_query_and_next_steps}'

--- a/fastworkflow/workflow_agent.py
+++ b/fastworkflow/workflow_agent.py
@@ -246,9 +246,15 @@ def _execute_workflow_query(command: str, chat_session_obj: fastworkflow.ChatSes
     # Handle parameter extraction errors with abort
     if nlu_stage == fastworkflow.NLUPipelineStage.PARAMETER_EXTRACTION:
         abort_confirmation = _execute_workflow_query('abort', chat_session_obj=chat_session_obj)
+        # Thread the active planning context so replanning uses the same planner LM
+        # and insights as the current turn (critical for distillation: otherwise
+        # replans silently fall back to LLM_PLANNER instead of the teacher/student LM).
+        planning_insights = getattr(chat_session_obj, '_planning_insights', None)
+        planner_lm = getattr(chat_session_obj, '_current_planner_lm', None)
         return build_query_with_next_steps(
-            f'{response_text}\n{abort_confirmation}', 
-            chat_session_obj, with_agent_inputs_and_trajectory = True
+            f'{response_text}\n{abort_confirmation}',
+            chat_session_obj, with_agent_inputs_and_trajectory=True,
+            planning_insights=planning_insights, planner_lm=planner_lm,
         )
 
     # Clean up the context flag after command execution
@@ -267,14 +273,14 @@ def _resolve_intent_misunderstanding(chat_session_obj, command, response_text):
     agent_inputs = workflow_tool_agent.inputs if workflow_tool_agent else {}
     agent_trajectory = workflow_tool_agent.current_trajectory if workflow_tool_agent else {}
 
-    lm = dspy_utils.get_lm("LLM_AGENT", "LITELLM_API_KEY_AGENT")
-    with dspy.context(lm=lm):
-        result = intent_agent(
-            original_command=command,
-            error_message=response_text,
-            agent_inputs=agent_inputs,
-            agent_trajectory=agent_trajectory,
-        )
+    # Inherit the ambient agent LM (set by the caller's dspy.context) rather than
+    # hardcoding LLM_AGENT.
+    result = intent_agent(
+        original_command=command,
+        error_message=response_text,
+        agent_inputs=agent_inputs,
+        agent_trajectory=agent_trajectory,
+    )
 
     return _resolve_or_escalate(result, chat_session_obj, response_text)
 
@@ -306,8 +312,7 @@ def _resolve_intent_ambiguity(chat_session_obj, cme_workflow, command, response_
     agent_inputs = workflow_tool_agent.inputs if workflow_tool_agent else {}
     agent_trajectory = workflow_tool_agent.current_trajectory if workflow_tool_agent else {}
 
-    lm = dspy_utils.get_lm("LLM_AGENT", "LITELLM_API_KEY_AGENT")
-    with dspy.context(lm=lm, adapter=agent_adapter):
+    with dspy.context(adapter=agent_adapter):
         result = intent_agent(
             original_command=command,
             error_message=response_text,
@@ -344,10 +349,14 @@ def _post_ask_user_response(
     if workflow:
         workflow.context["raw_user_message"] = user_response
 
+    planning_insights = getattr(chat_session_obj, '_planning_insights', None)
+    planner_lm = getattr(chat_session_obj, '_current_planner_lm', None)
     return build_query_with_next_steps(
         user_response,
         chat_session_obj,
         with_agent_inputs_and_trajectory=True,
+        planning_insights=planning_insights,
+        planner_lm=planner_lm,
     )
 
 
@@ -390,21 +399,42 @@ def _ask_user_tool(clarification_request: str, chat_session_obj: fastworkflow.Ch
         clarification_request, user_query, chat_session_obj
     )
 
-def initialize_workflow_tool_agent(chat_session: fastworkflow.ChatSession, max_iters: int = 25):
+def initialize_workflow_tool_agent(chat_session: fastworkflow.ChatSession, max_iters: int = 25,
+                                   execution_insights: str | None = None,
+                                   on_step_complete=None):
     """
     Initialize and return a DSPy ReAct agent that exposes individual MCP tools.
     Each tool expects a single query string for its specific tool.
-    
+
     Args:
         chat_session: fastworkflow.ChatSession instance
         max_iters: Maximum iterations for the ReAct agent
-        
+        execution_insights: Optional workflow-specific execution anti-patterns to
+            append to the agent signature docstring (knowledge distillation).
+        on_step_complete: Optional callback(step_idx, trajectory) -> bool for
+            step-by-step interception (distillation). Return False to stop early.
+
     Returns:
         DSPy ReAct agent configured with workflow tools
     """
     chat_session_obj = chat_session
     if not chat_session_obj:
         raise ValueError("chat session cannot be null")
+
+    # Build the agent signature. When execution insights are supplied, append them
+    # to WorkflowAgentSignature's instructions as anti-patterns to avoid; otherwise
+    # use the module-level WorkflowAgentSignature unchanged.
+    if execution_insights:
+        enhanced_docstring = (
+            f"{WorkflowAgentSignature.__doc__}\n\nCRITICAL ANTI-PATTERNS TO AVOID:\n{execution_insights}"
+        )
+
+        class AgentSignature(dspy.Signature):
+            __doc__ = enhanced_docstring
+            user_query = dspy.InputField(desc="The natural language user query.")
+            final_answer = dspy.OutputField(desc="Comprehensive final answer with supporting evidence to demonstrate that every user intent has been fully addressed.")
+    else:
+        AgentSignature = WorkflowAgentSignature
 
     def what_can_i_do() -> str:
         """
@@ -471,33 +501,48 @@ def initialize_workflow_tool_agent(chat_session: fastworkflow.ChatSession, max_i
     ]
 
     return fastWorkflowReAct(
-        WorkflowAgentSignature,
+        AgentSignature,
         tools=tools,
         max_iters=max_iters,
+        on_step_complete=on_step_complete,
     )
 
 
-def build_query_with_next_steps(user_query: str, 
-    chat_session_obj: fastworkflow.ChatSession, with_agent_inputs_and_trajectory: bool = False) -> str:
+def build_query_with_next_steps(user_query: str,
+    chat_session_obj: fastworkflow.ChatSession, with_agent_inputs_and_trajectory: bool = False,
+    planning_insights: str | None = None, planner_lm = None) -> str:
     """
     Generate a todo list.
     Return a string that combine the user query and todo list
+
+    Args:
+        user_query: The user's natural language query
+        chat_session_obj: The active chat session
+        with_agent_inputs_and_trajectory: Whether to include agent trajectory for replanning
+        planning_insights: Optional workflow-specific planning insights to append to
+            the planner signature docstring (knowledge distillation)
+        planner_lm: Optional planner LM to use (if None, uses LLM_PLANNER from env)
     """
+    base_docstring = """
+    Carefully review the user_query and generate a next steps sequence based only on available commands.
+    Walk the graph of commands based on the 'available_from' hints to build the most appropriate command sequence.
+
+    IMPORTANT: 9 times out of 10 information can be found via available commands. However, when generating the plan:
+    - If required information is missing and cannot be found via commands, explicitly specify in the plan that the user needs to be consulted
+    - If confirmation is needed before proceeding, explicitly specify in the plan that user confirmation is required
+    """
+    if planning_insights:
+        enhanced_docstring = f"{base_docstring}\n\nCRITICAL PATTERNS FOR THIS WORKFLOW:\n{planning_insights}"
+    else:
+        enhanced_docstring = base_docstring
+
     class TaskPlannerSignature(dspy.Signature):
-        """
-        Carefully review the user_query and generate a next steps sequence based only on available commands.
-        Walk the graph of commands based on the 'available_from' hints to build the most appropriate command sequence
-        Avoid specifying 'ask user' because 9 times out of 10, you can find the information via available commands. 
-        """
+        __doc__ = enhanced_docstring
         user_query: str = dspy.InputField()
         next_steps: str = dspy.OutputField(desc="task descriptions as a numbered list of short sentences separated by line breaks")
 
     class TaskPlannerWithTrajectoryAndAgentInputsSignature(dspy.Signature):
-        """
-        Carefully review agent inputs, agent trajectory and user response and generate a next steps sequence based only on available commands.
-        Walk the graph of commands based on the 'available_from' hints to build the most appropriate command sequence
-        Avoid specifying 'ask user' because 9 times out of 10, you can find the information via available commands. 
-        """
+        __doc__ = enhanced_docstring
         agent_inputs: dict = dspy.InputField()
         agent_trajectory: dict = dspy.InputField()
         user_response: str = dspy.InputField()
@@ -510,7 +555,9 @@ def build_query_with_next_steps(user_query: str,
         active_context_name=current_workflow.current_command_context_name,
     )
 
-    planner_lm = dspy_utils.get_lm("LLM_PLANNER", "LITELLM_API_KEY_PLANNER")
+    # Use provided planner_lm if available (distillation mode), else build from env
+    if planner_lm is None:
+        planner_lm = dspy_utils.get_lm("LLM_PLANNER", "LITELLM_API_KEY_PLANNER")
     agent_adapter = CommandsSystemPreludeAdapter()
     with dspy.context(lm=planner_lm, adapter=agent_adapter):
         if with_agent_inputs_and_trajectory:
@@ -532,6 +579,19 @@ def build_query_with_next_steps(user_query: str,
             return user_query
 
         steps_formatted = " ".join(prediction.next_steps.split())
+
+        # Capture the generated plan for distillation when a capture list is present
+        # on the session (set only during a DistillationSession planning pass).
+        planning_capture = getattr(chat_session_obj, '_planning_steps_capture', None)
+        if planning_capture is not None:
+            from fastworkflow.distillation import PlanningStep
+            planning_capture.append(PlanningStep(
+                step_number=len(planning_capture),
+                user_query=user_query,
+                generated_plan=steps_formatted,
+                reasoning=getattr(prediction, 'reasoning', ''),
+            ))
+
         user_query_and_next_steps = f"{user_query}\n\nExecute these next steps:\n{steps_formatted}"
         return (
             f'User Query:\n{user_query_and_next_steps}'

--- a/fastworkflow/workflow_execution_context.py
+++ b/fastworkflow/workflow_execution_context.py
@@ -62,12 +62,15 @@ class WorkflowExecutionContext:
         run_as_agent: bool = False,
         session_key: Optional[str] = None,
         mirror_action_log_to_file: bool = False,
+        generate_insights: bool = False,
     ):
         """
         Args:
             session_key: Stable id (e.g. channel_id) for cme/app workflow persistence.
                          When omitted, cme uses an ephemeral uuid (CLI one-off sessions).
             mirror_action_log_to_file: If True, also append to cwd action.jsonl (debug).
+            generate_insights: If True, enable teacher/student distillation on each
+                         agent turn (Topology A / CLI only).
         """
         self._session_key = session_key
         self._run_as_agent = run_as_agent
@@ -91,6 +94,12 @@ class WorkflowExecutionContext:
         self._awaiting_user = False
         self._suspended_user_message: Optional[str] = None
         self._pending_clarification_request: Optional[str] = None
+
+        # Insights-distillation (teacher/student) state — CLI/Topology-A only.
+        self._generate_insights = generate_insights
+        self._distillation_insights_count = 0
+        self._planning_insights: Optional[str] = None
+        self._execution_insights: Optional[str] = None
 
         # Turn accumulator state (one logical turn = one key, across suspensions)
         self._turn_outputs: list = []
@@ -666,8 +675,21 @@ class WorkflowExecutionContext:
         if self._app_workflow:
             self._app_workflow.context["run_as_agent"] = True
 
+        # Load workflow-specific insights for insights distillation (if present).
+        # These enhance the agent + planner signatures; absent files -> None (no-op).
+        from fastworkflow.utils.insights_loader import load_workflow_insights
+        if self._app_workflow:
+            self._planning_insights = load_workflow_insights(
+                self._app_workflow.folderpath, "planning_agent"
+            )
+            self._execution_insights = load_workflow_insights(
+                self._app_workflow.folderpath, "execution_agent"
+            )
+
         from fastworkflow.workflow_agent import initialize_workflow_tool_agent
-        self._workflow_tool_agent = initialize_workflow_tool_agent(self)
+        self._workflow_tool_agent = initialize_workflow_tool_agent(
+            self, execution_insights=self._execution_insights
+        )
 
         from fastworkflow.intent_clarification_agent import initialize_intent_clarification_agent
         self._intent_clarification_agent = initialize_intent_clarification_agent(self)
@@ -723,6 +745,8 @@ class WorkflowExecutionContext:
         command_info_and_refined_message_with_todolist = build_query_with_next_steps(
             refined_user_query,
             self,
+            planning_insights=self._planning_insights,
+            planner_lm=getattr(self, "_current_planner_lm", None),
         )
         available_commands = _what_can_i_do(self)
 
@@ -803,6 +827,19 @@ class WorkflowExecutionContext:
 
     def _process_agent_message(self, message: str) -> fastworkflow.CommandOutput:
         self._ensure_agent_initialized()
+
+        # Insights-distillation mode (CLI / Topology A only): run the teacher/student
+        # comparison, which drives its own agent passes and returns the student's
+        # CommandOutput. Guarded on user_message_queue so it can never run over a
+        # Topology-B suspended trajectory.
+        if self._generate_insights and self.user_message_queue is not None:
+            from fastworkflow.distillation import distill_message
+            result = distill_message(self, message)
+            self._distillation_insights_count += result.insights_extracted
+            self._maybe_enqueue_output(result.command_output)
+            self._maybe_enqueue_trace_sentinel()
+            return result.command_output
+
         agent_result = self._run_agent(message)
         self._turn_agent_result = agent_result
         if getattr(agent_result, "suspended", None) is True:

--- a/fastworkflow/workflow_execution_context.py
+++ b/fastworkflow/workflow_execution_context.py
@@ -742,9 +742,14 @@ class WorkflowExecutionContext:
 
         from fastworkflow.workflow_agent import build_query_with_next_steps, _what_can_i_do
 
+        # When there is prior conversation history, pass the agent trajectory and
+        # inputs to the planner so it does not re-plan steps already completed in
+        # earlier turns (uses TaskPlannerWithTrajectoryAndAgentInputsSignature).
+        has_history = bool(self.conversation_history.messages)
         command_info_and_refined_message_with_todolist = build_query_with_next_steps(
             refined_user_query,
             self,
+            with_agent_inputs_and_trajectory=has_history,
             planning_insights=self._planning_insights,
             planner_lm=getattr(self, "_current_planner_lm", None),
         )

--- a/fastworkflow/workflow_execution_context.py
+++ b/fastworkflow/workflow_execution_context.py
@@ -434,6 +434,40 @@ class WorkflowExecutionContext:
     def clear_conversation_history(self) -> None:
         self._conversation_history = dspy.History(messages=[])
 
+    def append_conversation_turn(
+        self,
+        conversation_summary: str,
+        conversation_traces: Optional[str] = None,
+        feedback: Optional[str] = None,
+    ) -> None:
+        """Append one turn to conversation history in the canonical 3-key shape."""
+
+        self._conversation_history.messages.append(
+            {
+                "conversation summary": conversation_summary,
+                "conversation_traces": conversation_traces,
+                "feedback": feedback,
+            }
+        )
+
+    def summarize_and_record_turn(
+        self, message: str, actions: list, result_text: str
+    ) -> tuple[str, Optional[str]]:
+        """Summarize a completed agent turn and append it to conversation history.
+
+        When there are executed actions, run LLM summarization; otherwise fall back
+        to the raw message. Appends the turn via append_conversation_turn and returns
+        (summary, traces) so callers can reuse them (e.g. to set an artifact).
+        """
+        conversation_summary = message
+        conversation_traces = None
+        if actions:
+            conversation_summary, conversation_traces = self._extract_conversation_summary(
+                message, actions, result_text
+            )
+        self.append_conversation_turn(conversation_summary, conversation_traces)
+        return conversation_summary, conversation_traces
+
     def bind_app_workflow(self, workflow: fastworkflow.Workflow) -> None:
         """Bind the app workflow for NLU (Path 1) and execution (Path 2)."""
         self._app_workflow = workflow
@@ -715,10 +749,17 @@ class WorkflowExecutionContext:
 
         return lm, CommandsSystemPreludeAdapter()
 
-    def _call_agent_with_retry(self, agent_call):
+    def _call_agent_with_retry(self, agent_call, lm=None):
+        """Run agent_call under an agent dspy.context, retrying on AdapterParseError.
+
+        lm: optional LM override (e.g. distillation's teacher/student model). When
+        omitted, the default agent context (LLM_AGENT) is used.
+        """
         from dspy.utils.exceptions import AdapterParseError
 
-        lm, agent_adapter = self._agent_dspy_context()
+        default_lm, agent_adapter = self._agent_dspy_context()
+        if lm is None:
+            lm = default_lm
         max_retries = 2
         for attempt in range(max_retries):
             try:
@@ -790,21 +831,11 @@ class WorkflowExecutionContext:
 
         command_response = fastworkflow.CommandResponse(response=result_text)
 
-        conversation_traces = None
-        conversation_summary = original_message
-        if self._action_log:
-            conversation_summary, conversation_traces = self._extract_conversation_summary(
-                original_message, self._action_log, result_text
-            )
-            command_response.artifacts["conversation_summary"] = conversation_summary
-
-        self.conversation_history.messages.append(
-            {
-                "conversation summary": conversation_summary,
-                "conversation_traces": conversation_traces,
-                "feedback": None,
-            }
+        conversation_summary, _ = self.summarize_and_record_turn(
+            original_message, self._action_log, result_text
         )
+        if self._action_log:
+            command_response.artifacts["conversation_summary"] = conversation_summary
 
         # Topic 5: the synthesized agent answer carries only its own artifacts (e.g.
         # conversation_summary), so structured outputs from tool calls during the turn
@@ -937,12 +968,8 @@ class WorkflowExecutionContext:
             "response": response_text,
         }
 
-        self.conversation_history.messages.append(
-            {
-                "conversation summary": "assistant_mode_command",
-                "conversation_traces": json.dumps(record),
-                "feedback": None,
-            }
+        self.append_conversation_turn(
+            "assistant_mode_command", json.dumps(record)
         )
 
         self._maybe_enqueue_output(command_output)
@@ -1007,12 +1034,8 @@ class WorkflowExecutionContext:
             "response": response_text,
         }
 
-        self.conversation_history.messages.append(
-            {
-                "conversation summary": "process_action command",
-                "conversation_traces": json.dumps(record),
-                "feedback": None,
-            }
+        self.append_conversation_turn(
+            "process_action command", json.dumps(record)
         )
 
         self._maybe_enqueue_output(command_output)
@@ -1023,14 +1046,17 @@ class WorkflowExecutionContext:
     def _refine_user_query(
         self, user_query: str, conversation_history: dspy.History
     ) -> str:
-        if conversation_history.messages:
-            messages = []
-            for conv_dict in conversation_history.messages[-5:]:
-                messages.extend([f"{k}: {v}" for k, v in conv_dict.items()])
-            messages.append(f"new_user_query: {user_query}")
-            return "\n".join(messages)
-
-        return user_query
+        if not conversation_history.messages:
+            return user_query
+        messages = []
+        for conv_dict in conversation_history.messages[-5:]:
+            messages.extend(
+                f"{k}: {v}"
+                for k, v in conv_dict.items()
+                if k != "conversation_traces"
+            )
+        messages.append(f"new_user_query: {user_query}")
+        return "\n".join(messages)
 
     def _extract_conversation_summary(
         self,

--- a/tests/test_distillation_core.py
+++ b/tests/test_distillation_core.py
@@ -1,0 +1,199 @@
+"""Unit tests for distillation's pure comparison/formatting/persistence logic.
+
+These cover the LLM-free core of fastworkflow/distillation.py — trajectory and
+plan comparison, trajectory formatting for the insight LLM, and numbered-insight
+persistence — without any network/LLM dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastworkflow.distillation import (
+    DistillationSession,
+    PlanningStep,
+    DistillationResult,
+)
+
+
+@pytest.fixture
+def session() -> DistillationSession:
+    # The comparison/formatting methods don't touch WEC state, so build an
+    # instance without running __init__ (no WEC needed).
+    return DistillationSession.__new__(DistillationSession)
+
+
+# ---------------------------------------------------------------------------
+# _action_signature / _format_action
+# ---------------------------------------------------------------------------
+
+def test_action_signature_is_order_independent_for_params():
+    a1 = {"command_name": "cancel_order", "parameters": {"id": "1", "reason": "x"}}
+    a2 = {"command_name": "cancel_order", "parameters": {"reason": "x", "id": "1"}}
+    # Same command + same params (different dict order) -> identical signature.
+    assert DistillationSession._action_signature(a1) == DistillationSession._action_signature(a2)
+
+
+def test_action_signature_differs_on_params():
+    a1 = {"command_name": "cancel_order", "parameters": {"id": "1"}}
+    a2 = {"command_name": "cancel_order", "parameters": {"id": "2"}}
+    assert DistillationSession._action_signature(a1) != DistillationSession._action_signature(a2)
+
+
+def test_format_action_with_and_without_params():
+    assert DistillationSession._format_action(
+        {"command_name": "get_order", "parameters": {"id": "1"}}
+    ) == 'get_order({"id": "1"})'
+    # No params -> bare command name.
+    assert DistillationSession._format_action(
+        {"command_name": "list_all", "parameters": {}}
+    ) == "list_all"
+
+
+# ---------------------------------------------------------------------------
+# compare_trajectories (action-level divergence + is_valid_action filter)
+# ---------------------------------------------------------------------------
+
+def test_compare_trajectories_identical_no_divergence(session):
+    actions = [
+        {"command_name": "find_user", "parameters": {"email": "a@b.com"}},
+        {"command_name": "get_order", "parameters": {"id": "1"}},
+    ]
+    diverged, summary = session.compare_trajectories(list(actions), list(actions))
+    assert diverged is False
+    assert summary == ""
+
+
+def test_compare_trajectories_detects_extra_student_action(session):
+    teacher = [{"command_name": "find_user", "parameters": {"email": "a@b.com"}}]
+    student = [
+        {"command_name": "find_user", "parameters": {"email": "a@b.com"}},
+        {"command_name": "get_user_details", "parameters": {"user_id": "u1"}},
+    ]
+    diverged, summary = session.compare_trajectories(teacher, student)
+    assert diverged is True
+    assert "get_user_details" in summary
+
+
+def test_compare_trajectories_filters_ask_user_and_error_correction(session):
+    # ask_user records (agent_query key) and ErrorCorrection/* must be excluded
+    # from the command-level divergence comparison.
+    teacher = [
+        {"agent_query": "email?", "user_response": "a@b.com"},           # ask_user
+        {"command_name": "ErrorCorrection/abort", "parameters": {}},     # abort
+        {"command_name": "find_user", "parameters": {"email": "a@b.com"}},
+    ]
+    student = [
+        {"command_name": "find_user", "parameters": {"email": "a@b.com"}},
+    ]
+    # After filtering, both reduce to the same single find_user action.
+    diverged, summary = session.compare_trajectories(teacher, student)
+    assert diverged is False
+    assert summary == ""
+
+
+# ---------------------------------------------------------------------------
+# compare_planning_traces
+# ---------------------------------------------------------------------------
+
+def test_compare_planning_traces_identical(session):
+    t = [PlanningStep(0, "q", ["step a", "step b"])]
+    s = [PlanningStep(0, "q", ["step a", "step b"])]
+    diverged, summary = session.compare_planning_traces(t, s)
+    assert diverged is False
+
+
+def test_compare_planning_traces_detects_difference(session):
+    t = [PlanningStep(0, "q", ["step a", "step b"])]
+    s = [PlanningStep(0, "q", ["step a", "different"])]
+    diverged, summary = session.compare_planning_traces(t, s)
+    assert diverged is True
+    assert "Step 0" in summary
+
+
+def test_compare_planning_traces_empty_both(session):
+    assert session.compare_planning_traces([], []) == (False, "")
+
+
+# ---------------------------------------------------------------------------
+# _format_trajectory_for_llm (must surface ask_user steps + observations)
+# ---------------------------------------------------------------------------
+
+def test_format_trajectory_includes_ask_user_and_observations():
+    trajectory = {
+        "thought_0": "need email",
+        "tool_name_0": "ask_user",
+        "tool_args_0": {"clarification_request": "email?"},
+        "observation_0": "mia@example.com",       # user's answer
+        "thought_1": "look up",
+        "tool_name_1": "execute_workflow_query",
+        "tool_args_1": {"command": "find_user"},
+        "observation_1": "user id: u1",
+    }
+    out = DistillationSession._format_trajectory_for_llm(trajectory)
+    # ask_user step and the user's answer must reach the insight LLM.
+    assert "ask_user" in out
+    assert "mia@example.com" in out
+    assert "execute_workflow_query" in out
+    assert "user id: u1" in out
+
+
+def test_format_trajectory_truncates_long_observations():
+    trajectory = {
+        "thought_0": "t",
+        "tool_name_0": "x",
+        "tool_args_0": {},
+        "observation_0": "A" * 900,
+    }
+    out = DistillationSession._format_trajectory_for_llm(trajectory)
+    assert "[truncated]" in out
+
+
+# ---------------------------------------------------------------------------
+# _append_numbered_insights (numbering continuity across appends)
+# ---------------------------------------------------------------------------
+
+def test_append_numbered_insights_starts_at_one_then_continues(tmp_path: Path):
+    f = tmp_path / "insights.md"
+    fmt = "{num}. {insight}\n"
+    pattern = r"^(\d+)\.\s"
+    header = "# Insights\n\n"
+
+    DistillationSession._append_numbered_insights(["first"], f, header, pattern, fmt)
+    DistillationSession._append_numbered_insights(["second", "third"], f, header, pattern, fmt)
+
+    content = f.read_text(encoding="utf-8")
+    assert "1. first" in content
+    assert "2. second" in content
+    assert "3. third" in content
+    # Header written exactly once.
+    assert content.count("# Insights") == 1
+
+
+def test_append_numbered_planning_insights_uses_its_own_pattern(tmp_path: Path):
+    f = tmp_path / "planning.md"
+    fmt = "## {num}. {insight}\n\n"
+    pattern = r"^## (\d+)\."
+    header = "# Planning\n\n"
+
+    DistillationSession._append_numbered_insights(["a"], f, header, pattern, fmt)
+    DistillationSession._append_numbered_insights(["b"], f, header, pattern, fmt)
+
+    content = f.read_text(encoding="utf-8")
+    assert "## 1. a" in content
+    assert "## 2. b" in content
+
+
+# ---------------------------------------------------------------------------
+# DistillationResult
+# ---------------------------------------------------------------------------
+
+def test_distillation_result_total_insights():
+    r = DistillationResult(
+        command_output=None,
+        planning_insights_extracted=2,
+        execution_insights_extracted=3,
+    )
+    assert r.insights_extracted == 5

--- a/tests/test_execution_context_agent.py
+++ b/tests/test_execution_context_agent.py
@@ -178,6 +178,50 @@ def _make_agent_ctx(initialized_fastworkflow, todo_workflow_path, monkeypatch):
     return ctx, wf
 
 
+def test_run_agent_threads_planning_context_to_planner(
+    initialized_fastworkflow,
+    todo_workflow_path,
+    monkeypatch,
+):
+    """_run_agent must forward the session's planning_insights and the stashed
+    planner LM (_current_planner_lm) to build_query_with_next_steps. This guards
+    the planner-LM/insights wiring that distillation depends on — a regression
+    here silently reverts replans to the default LLM_PLANNER.
+    """
+    ctx, _wf = _make_agent_ctx(initialized_fastworkflow, todo_workflow_path, monkeypatch)
+
+    sentinel_insights = "PLANNING_INSIGHTS_SENTINEL"
+    sentinel_planner_lm = object()
+    ctx._planning_insights = sentinel_insights
+    ctx._current_planner_lm = sentinel_planner_lm
+
+    captured: dict = {}
+
+    def capturing_planner(user_query, session, **kwargs):
+        captured["planning_insights"] = kwargs.get("planning_insights")
+        captured["planner_lm"] = kwargs.get("planner_lm")
+        return user_query
+
+    monkeypatch.setattr(
+        "fastworkflow.workflow_agent.build_query_with_next_steps",
+        capturing_planner,
+    )
+
+    # Mock the agent + retry wrapper so _run_agent returns after the planner call
+    mock_agent = MagicMock()
+    _set_agents(ctx, mock_agent)
+    monkeypatch.setattr(
+        ctx,
+        "_call_agent_with_retry",
+        lambda agent_call, lm=None: SimpleNamespace(final_answer="done"),
+    )
+
+    ctx.process_message("do the thing")
+
+    assert captured["planning_insights"] is sentinel_insights
+    assert captured["planner_lm"] is sentinel_planner_lm
+
+
 def test_topology_b_ask_user_suspend_resume_round_trip(
     initialized_fastworkflow,
     todo_workflow_path,

--- a/tests/test_execution_context_agent.py
+++ b/tests/test_execution_context_agent.py
@@ -73,7 +73,7 @@ def test_process_message_agent_mode_mocked_agent(
 
     monkeypatch.setattr(
         "fastworkflow.workflow_agent.build_query_with_next_steps",
-        lambda user_query, session: user_query,
+        lambda user_query, session, **kwargs: user_query,
     )
     monkeypatch.setattr(
         "fastworkflow.workflow_agent._what_can_i_do",
@@ -138,7 +138,7 @@ def test_process_message_converts_ask_user_cancel_to_output(
 
     monkeypatch.setattr(
         "fastworkflow.workflow_agent.build_query_with_next_steps",
-        lambda user_query, session: user_query,
+        lambda user_query, session, **kwargs: user_query,
     )
     monkeypatch.setattr(
         "fastworkflow.workflow_agent._what_can_i_do",
@@ -163,7 +163,7 @@ def _make_agent_ctx(initialized_fastworkflow, todo_workflow_path, monkeypatch):
 
     monkeypatch.setattr(
         "fastworkflow.workflow_agent.build_query_with_next_steps",
-        lambda user_query, session, with_agent_inputs_and_trajectory=False: user_query,
+        lambda user_query, session, with_agent_inputs_and_trajectory=False, **kwargs: user_query,
     )
     monkeypatch.setattr(
         "fastworkflow.workflow_agent._what_can_i_do",
@@ -396,7 +396,7 @@ def test_topology_a_cli_ask_user_blocks_with_queue(
 
     monkeypatch.setattr(
         "fastworkflow.workflow_agent.build_query_with_next_steps",
-        lambda user_query, session, with_agent_inputs_and_trajectory=False: (
+        lambda user_query, session, with_agent_inputs_and_trajectory=False, **kwargs: (
             f"replanned:{user_query}"
         ),
     )
@@ -441,7 +441,7 @@ def test_topology_a_cli_ask_user_pairs_output_with_trace_sentinel(
 
     monkeypatch.setattr(
         "fastworkflow.workflow_agent.build_query_with_next_steps",
-        lambda user_query, session, with_agent_inputs_and_trajectory=False: (
+        lambda user_query, session, with_agent_inputs_and_trajectory=False, **kwargs: (
             f"replanned:{user_query}"
         ),
     )

--- a/tests/test_parameter_extraction_unit.py
+++ b/tests/test_parameter_extraction_unit.py
@@ -1,0 +1,94 @@
+"""Unit tests for the parameter-extraction robustness helpers.
+
+Covers _unwrap_optional (Optional/Union unwrapping) and the XML list-field
+extraction (repeated tags collected via findall, robust list parsing). Pure
+logic — no LLM/network.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from fastworkflow._workflows.command_metadata_extraction.parameter_extraction import (
+    _unwrap_optional,
+    ParameterExtraction,
+)
+
+
+# ---------------------------------------------------------------------------
+# _unwrap_optional
+# ---------------------------------------------------------------------------
+
+def test_unwrap_optional_plain_type_unchanged():
+    inner, origin = _unwrap_optional(str)
+    assert inner is str
+    assert origin is None
+
+
+def test_unwrap_optional_unwraps_optional():
+    inner, origin = _unwrap_optional(Optional[str])
+    assert inner is str
+
+
+def test_unwrap_optional_unwraps_optional_list_to_list_origin():
+    inner, origin = _unwrap_optional(Optional[List[str]])
+    # Origin should be list so callers can detect list fields.
+    assert origin is list
+
+
+def test_unwrap_optional_union_with_none():
+    inner, _ = _unwrap_optional(Union[int, None])
+    assert inner is int
+
+
+# ---------------------------------------------------------------------------
+# _extract_parameters_from_xml — list fields via repeated tags
+# ---------------------------------------------------------------------------
+
+class _ListParams(BaseModel):
+    order_id: str = Field(default="NOT_FOUND")
+    item_ids: List[str] = Field(default_factory=list)
+
+
+def test_xml_extraction_collects_repeated_list_tags():
+    # An agent may repeat a list tag once per item; all must be collected
+    # (regression: re.search dropped all but the first).
+    command = (
+        "<order_id>#W1</order_id> "
+        "<item_ids>a</item_ids> <item_ids>b</item_ids> <item_ids>c</item_ids>"
+    )
+    result = ParameterExtraction._extract_parameters_from_xml(command, _ListParams)
+    assert result is not None
+    assert result.order_id == "#W1"
+    assert result.item_ids == ["a", "b", "c"]
+
+
+def test_xml_extraction_single_list_item():
+    command = "<order_id>#W1</order_id> <item_ids>only</item_ids>"
+    result = ParameterExtraction._extract_parameters_from_xml(command, _ListParams)
+    assert result is not None
+    assert result.item_ids == ["only"]
+
+
+class _MultiParams(BaseModel):
+    order_id: str = Field(default="NOT_FOUND")
+    reason: str = Field(default="NOT_FOUND")
+
+
+def test_xml_extraction_multiple_scalar_fields():
+    command = "<order_id>#W123</order_id> <reason>no longer needed</reason>"
+    result = ParameterExtraction._extract_parameters_from_xml(command, _MultiParams)
+    assert result is not None
+    assert result.order_id == "#W123"
+    assert result.reason == "no longer needed"
+
+
+def test_xml_extraction_no_params_returns_empty_model():
+    class _NoParams(BaseModel):
+        pass
+
+    result = ParameterExtraction._extract_parameters_from_xml("anything", _NoParams)
+    assert result is not None
+    assert isinstance(result, _NoParams)

--- a/tests/test_react_suspend_resume.py
+++ b/tests/test_react_suspend_resume.py
@@ -75,6 +75,61 @@ def test_resume_continues_after_observation():
     assert agent._suspended is None
 
 
+def test_run_loop_mirrors_full_step_into_current_trajectory():
+    """A completed tool step must populate current_trajectory with thought,
+    tool_name, tool_args, and observation (not just an action summary), because
+    the planner and distillation read current_trajectory as the agent trajectory."""
+    agent = _bare_react_agent(
+        do_it=lambda: "did it",
+        finish=lambda: "done",
+    )
+
+    preds = iter([
+        SimpleNamespace(next_thought="act", next_tool_name="do_it", next_tool_args={}),
+        SimpleNamespace(next_thought="stop", next_tool_name="finish", next_tool_args={}),
+    ])
+    agent.react = lambda trajectory, **input_args: next(preds)  # type: ignore[method-assign]
+    agent.extract = lambda trajectory, **input_args: {"final_answer": "ok"}  # type: ignore[method-assign]
+
+    result = agent._run_loop({}, 0, {"query": "hello"}, max_iters=5, exception_count=0)
+
+    assert result is None  # completed normally
+    ct = agent.current_trajectory
+    assert ct["thought_0"] == "act"
+    assert ct["tool_name_0"] == "do_it"
+    assert ct["observation_0"] == "did it"
+    assert ct["tool_args_0"] == {}
+
+
+def test_resume_mirrors_user_answer_into_current_trajectory():
+    """The resumed observation (the user's ask_user answer) must land in
+    current_trajectory, not only in the local working trajectory."""
+    agent = _bare_react_agent(finish=lambda: "done")
+    # Pre-suspend, current_trajectory already holds the pre-ask_user step.
+    agent.current_trajectory = {
+        "thought_0": "ask",
+        "tool_name_0": "ask_user",
+        "tool_args_0": {},
+    }
+    trajectory = {"thought_0": "ask", "tool_name_0": "ask_user", "tool_args_0": {}}
+    agent._suspended = {
+        "trajectory": trajectory,
+        "idx": 0,
+        "input_args": {"query": "hello"},
+        "max_iters": 5,
+        "clarification": "Which one?",
+    }
+    agent.extract = lambda trajectory, **input_args: {"final_answer": "finished"}  # type: ignore[method-assign]
+    agent.react = lambda trajectory, **input_args: SimpleNamespace(  # type: ignore[method-assign]
+        next_thought="got answer", next_tool_name="finish", next_tool_args={}
+    )
+
+    agent.resume("user said B")
+
+    # The user's answer is recorded as observation_0 in current_trajectory.
+    assert agent.current_trajectory["observation_0"] == "user said B"
+
+
 def test_clear_suspension_drops_stash():
     agent = _bare_react_agent()
     agent._suspended = {"trajectory": {}, "idx": 0, "input_args": {}, "max_iters": 5}

--- a/tests/test_react_suspend_resume.py
+++ b/tests/test_react_suspend_resume.py
@@ -101,6 +101,56 @@ def test_run_loop_mirrors_full_step_into_current_trajectory():
     assert ct["tool_args_0"] == {}
 
 
+def test_current_trajectory_resets_each_forward_turn():
+    """current_trajectory is per-logical-turn: forward() must reset it at the
+    start of each new turn so a later turn does not accumulate the prior turn's
+    steps. (resume() must NOT reset — covered separately.)"""
+    agent = _bare_react_agent(do_it=lambda: "did it", finish=lambda: "done")
+    agent._exhausted_last_run = False
+    agent._suspended = None
+    agent.max_iters = 5
+    # _bare_react_agent skips __init__; provide the submodule attrs that forward()
+    # passes to _call_with_potential_trajectory_truncation (our mock ignores them).
+    agent.react = object()
+    agent.extract = object()
+
+    def make_turn(num_tool_steps: int):
+        # `num_tool_steps` tool calls then finish, per forward() call. Turn 1 runs
+        # MORE steps than turn 2 so that, if the reset is missing, turn 1's higher-
+        # index keys survive into turn 2 (detectable), rather than being overwritten.
+        preds = iter(
+            [
+                SimpleNamespace(next_thought=f"act{i}", next_tool_name="do_it", next_tool_args={})
+                for i in range(num_tool_steps)
+            ]
+            + [SimpleNamespace(next_thought="stop", next_tool_name="finish", next_tool_args={})]
+        )
+
+        def call(module, trajectory, **input_args):
+            try:
+                return next(preds)
+            except StopIteration:
+                return {"final_answer": "ok"}
+
+        return call
+
+    # Turn 1: 3 tool steps -> populates indices up to thought_3/observation_3.
+    agent._call_with_potential_trajectory_truncation = make_turn(3)  # type: ignore[method-assign]
+    agent.forward(query="first")
+    assert "observation_3" in agent.current_trajectory  # deep turn
+
+    # Turn 2: 1 tool step -> only indices 0 and 1. If forward() reset the mirror,
+    # the leftover observation_3 from turn 1 must be GONE.
+    agent._call_with_potential_trajectory_truncation = make_turn(1)  # type: ignore[method-assign]
+    agent.forward(query="second")
+    second_keys = set(agent.current_trajectory.keys())
+
+    assert "thought_0" in second_keys
+    # The load-bearing assertion: turn 1's deep keys did not survive into turn 2.
+    assert "observation_3" not in second_keys
+    assert "thought_2" not in second_keys
+
+
 def test_resume_mirrors_user_answer_into_current_trajectory():
     """The resumed observation (the user's ask_user answer) must land in
     current_trajectory, not only in the local working trajectory."""


### PR DESCRIPTION
## Summary

Adds a new **insights-distillation** capability plus a set of robustness improvements to parameter extraction, the ReAct agent, and the planner. These changes let small models learn from a stronger "teacher" model, improve XML/list parameter extraction, and make agent planning and replanning more reliable.

## New: Insights Distillation (`--generate_insights`)

A teacher/student knowledge-distillation mode for the CLI agent. On each user turn it runs a **teacher** (large model) and a **student** (small model) over the same message, compares their planning traces and executed actions, and extracts insights on divergence:

- **Planning insights** ("what TO DO") → `planning_agent_insights.md`
- **Execution anti-patterns** ("what NOT to do") → `execution_agent_anti_patterns.md`

Extracted insights are auto-loaded on subsequent runs and injected into the agent and planner signatures, so the workflow's agents and planner improve over time.

- New module `fastworkflow/distillation.py` — teacher/student orchestration, trajectory/action comparison, LLM-based insight extraction, and persistence.
- New module `fastworkflow/utils/insights_loader.py` — loads workflow-specific planning/execution insights from `Insights/<workflow>/`.
- New `--generate_insights` CLI flag (`fastworkflow run ... --generate_insights`); prints teacher/student phase banners and a per-turn divergence summary, and reports total insights extracted on `//exit`.
- Requires teacher/student model config: `LLM_TEACHER_AGENT`, `LLM_TEACHER_PLANNER`, `LLM_STUDENT_AGENT`, `LLM_STUDENT_PLANNER`, `LLM_DISTILLATION` (+ matching `LITELLM_API_KEY_*`). 

## Parameter extraction robustness (`parameter_extraction.py`, `signatures.py`)

- Handle `Optional[X]` / `Union[X, None]` uniformly via an `_unwrap_optional` helper.
- **List-field support**: repeated XML tags (`<ids>a</ids> <ids>b</ids>`) are now collected via `findall` instead of dropping all but the first; robust list parsing (JSON array, Python literal, comma- and space-separated, single value) with per-item type coercion.
- Coerce `BaseModel` list items from dicts; treat empty lists as "missing" for required list fields.

## Agent / planner improvements

- **Full-trajectory context for planner and distillation**: the agent's `current_trajectory` now carries the complete per-step trajectory (thought, tool name, tool args, observation) instead of action-only summaries. This restores rich context to (a) the planner during replanning and (b) the distillation insight-extractor. The resumed observation at the ask_user suspend/resume boundary (the user's answer) is mirrored in as well, so it is never dropped. `current_trajectory` remains a separate object from the suspended working dict, so suspend/resume behavior is unchanged.
- **History-aware replanning**: when a turn has prior conversation history, the planner is given the agent trajectory and inputs (`with_agent_inputs_and_trajectory=True`), so it does not re-plan steps that were already completed in earlier turns.
- **ReAct agent** (`react.py`): graceful fallback when the LM returns an empty/invalid prediction (returns a well-formed answer instead of crashing); optional `on_step_complete` step hook for trajectory interception.
- Dynamic agent/planner signatures that append workflow-specific execution/planning insights when present.

## Testing

Added unit tests for the ReAct suspend/resume trajectory mirroring (including the resume-boundary case). No new failures introduced.

## Summary by Sourcery

Introduce an insights-distillation mode that runs teacher/student agents, logs their behavior, and derives reusable planning/execution insights while hardening parameter extraction and agent/planner behavior.

New Features:
- Add a teacher/student insights-distillation pipeline that compares teacher and student planning and execution, extracts insights with a dedicated LLM, and persists them per workflow.
- Introduce workflow-specific insights loading and dynamic injection of planning and execution insights into agent and planner signatures.
- Expose a --generate_insights CLI flag and session plumbing to enable distillation mode and report extracted insights in the CLI agent flow.

Enhancements:
- Improve XML-based parameter extraction with robust Optional/Union handling, list-field parsing, and BaseModel coercion, treating empty lists as missing for required list fields.
- Make the ReAct agent more reliable by mirroring full per-step trajectories (including ask_user resumes), adding a step-completion hook, and falling back gracefully when the LM returns invalid predictions.
- Enhance planner behavior with history-aware replanning, optional planner LM injection, and support for workflow-specific planning insights in its prompt.
- Ensure intent clarification and parameter-extraction flows use shared LM utilities and ambient LM contexts instead of hardcoded models.

Tests:
- Add unit tests to verify full-trajectory mirroring across ReAct suspend/resume and update existing execution-context tests for the extended planning API.