### PR TITLE
feat: v2.23.0 — insights distillation, robust parameter extraction, and agent replanning fidelity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/radiantlogicinc/fastworkflow"
 
 [tool.poetry]
 name = "fastworkflow"
-version = "2.22.3"
+version = "2.23.0"
 description = "A framework for rapidly building large-scale, deterministic, interactive workflows with a fault-tolerant, conversational UX"
 authors = ["Dhar Rawal <drawal@radiantlogic.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release bump to **v2.23.0** for capabilities already on `main` via #44 (and related agentic work in #43).

- **Insights distillation** (`--generate_insights`): teacher/student mode that compares planning/execution traces and persists planning insights + execution anti-patterns for later agent/planner injection
- **Parameter extraction robustness**: uniform `Optional`/`Union` unwrapping, list-field XML/`findall` parsing with multi-format coercion, empty-list-as-missing for required lists
- **Agent/planner fidelity**: full per-step trajectory context for replanning and distillation, history-aware replanning, graceful ReAct fallback on empty/invalid LM predictions

## Test plan

- [ ] Confirm `pyproject.toml` version is `2.23.0` after merge
- [ ] Tag `v2.23.0` and publish the GitHub Release (notes prepared in this PR)
- [ ] Optional: `make publish` / `make publish-testpypi` after tag lands on `main`


Made with [Cursor](https://cursor.com)