### PR TITLE
Fix training behavior for thin labels and missing provenance

### DIFF
--- a/fastworkflow/model_pipeline_training.py
+++ b/fastworkflow/model_pipeline_training.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, ClassVar, Optional
+from typing import Callable, ClassVar, Iterable, Optional
 from transformers import AutoTokenizer, AutoModel, AutoModelForSequenceClassification
 from torch.optim import AdamW
 from sklearn.decomposition import PCA
@@ -55,50 +55,91 @@ class TrainingDataError(ValueError):
     """Raised before model fitting when a label cannot be trained and evaluated."""
 
 
+def _name_labels(
+    labels: Iterable[int],
+    decode_label: Optional[Callable[[int], str]] = None,
+) -> str:
+    """Render labels as a plain comma-separated list, sorted for a stable message.
+
+    Deliberately not a list repr. `decode_label` returns a numpy string, so a repr
+    renders as `[np.str_('cmd')]`, and the report prints through a rich console that
+    reads a bracketed run with no spaces as console markup and deletes it - which
+    silently dropped the one detail these messages exist to carry.
+    """
+    names = sorted(
+        str(decode_label(label)) if decode_label else str(label) for label in labels
+    )
+    return ", ".join(names)
+
+
 def split_training_data(
     dataset: list[tuple[str, int]],
     decode_label: Optional[Callable[[int], str]] = None,
 ) -> tuple[list[tuple[str, int]], list[tuple[str, int]]]:
     """Create a deterministic, class-aware train/evaluation split.
 
-    Every label must contribute at least one row to both sets. This replaces the
-    unstratified 25% split that could randomly put every row for a small class in the
-    evaluation set, leaving the classifier unable to learn that command.
+    Every label that *can* appear on both sides does. A label with fewer rows than
+    `heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL` cannot be stratified, so it trains
+    and goes unmeasured rather than failing the run: that is already what the persona
+    holdout does when its own split would starve a label, and aborting here instead
+    spends the entire LLM and GPU budget only to publish nothing - over a label whose
+    evaluation coverage the developer may never have wanted. Being unmeasured is
+    reported, not fatal.
+
+    Splitting still replaces the unstratified 25% split that could randomly put every
+    row for a small class in the evaluation set, leaving the classifier unable to learn
+    that command.
 
     ``decode_label`` turns the encoded label back into its command name for the
-    error message. Without it the abort names labels the developer cannot map to
-    commands without reverse-engineering the LabelEncoder, which is the state
-    this argument exists to prevent.
+    warning and error messages. Without it those messages name labels the developer
+    cannot map to commands without reverse-engineering the LabelEncoder, which is the
+    state this argument exists to prevent.
     """
     label_counts = Counter(label for _, label in dataset)
-    starved = sorted(
+    unmeasurable = {
         label
         for label, count in label_counts.items()
         if count < heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL
-    )
-    if starved:
-        named = [decode_label(label) for label in starved] if decode_label else starved
-        raise TrainingDataError(
-            f"Each intent label needs at least "
-            f"{heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL} rows (one for training "
-            f"and one for evaluation); labels with fewer rows: {named}"
+    }
+    # Partition rather than filter, so the unmeasurable rows still reach the model. They
+    # are appended in dataset order to keep the split reproducible.
+    splittable = [row for row in dataset if row[1] not in unmeasurable]
+    unmeasured_rows = [row for row in dataset if row[1] in unmeasurable]
+    if unmeasurable:
+        logger.warning(
+            f"{len(unmeasurable)} intent label(s) have fewer than "
+            f"{heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL} rows, so they train "
+            f"without an evaluation row and are unmeasured on the routing axis: "
+            f"{_name_labels(unmeasurable, decode_label)}"
         )
 
+    label_counts = Counter(label for _, label in splittable)
     label_count = len(label_counts)
-    test_size = max((len(dataset) + 3) // 4, label_count)
-    if len(dataset) - test_size < label_count:
+    if not label_count:
+        # Nothing can be measured, so there is no evaluation set to tune a threshold
+        # against and no score to publish. That is a different failure from one thin
+        # label and stays fatal.
         raise TrainingDataError(
-            f"Cannot split {len(dataset)} rows across {label_count} labels while keeping "
-            "at least one row per label in both training and evaluation sets."
+            f"No intent label has the "
+            f"{heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL} rows needed to form an "
+            f"evaluation set; every label is below the floor: "
+            f"{_name_labels(unmeasurable, decode_label)}"
+        )
+
+    test_size = max((len(splittable) + 3) // 4, label_count)
+    if len(splittable) - test_size < label_count:
+        raise TrainingDataError(
+            f"Cannot split {len(splittable)} rows across {label_count} labels while "
+            "keeping at least one row per label in both training and evaluation sets."
         )
 
     train_data, test_data = train_test_split(
-        dataset,
+        splittable,
         test_size=test_size,
         random_state=42,
-        stratify=[label for _, label in dataset],
+        stratify=[label for _, label in splittable],
     )
-    return list(train_data), list(test_data)
+    return list(train_data) + unmeasured_rows, list(test_data)
 
 
 def save_label_encoder(filepath):

--- a/fastworkflow/train/training_report.py
+++ b/fastworkflow/train/training_report.py
@@ -153,9 +153,11 @@ class RowStatus(str, Enum):
     #: The command has `Signature.Input`, but its generator returned no rows in at
     #: least one context. This is an explicit trainer skip, not missing provenance.
     NO_UTTERANCES = "no_utterances"
-    #: The command should have generated utterances but has no provenance record.
-    #: Either it was never reached (a training run that died part-way) or provenance
-    #: was lost. Distinct from EXCLUDED, which is by design.
+    #: The command has no provenance record AND no context provenance showing it was
+    #: trained: either it was never reached (a training run that died part-way) or
+    #: provenance was lost. Distinct from EXCLUDED, which is by design, and from a
+    #: command that supplies hand-written utterances without calling the generator -
+    #: that one has nothing to record and is judged on its row count.
     MISSING = "missing"
     #: No `Signature.Input`, so `model_pipeline_training._requires_utterances` returns
     #: False and the command is deliberately not an intent-detection label at all. It
@@ -671,6 +673,9 @@ def _classify_status(
     put a non-command at the top of a list of broken commands. A reserved label that
     genuinely fell back is still surfaced, because a degraded escalation class
     degrades the workflow like anything else.
+
+    Absent generation provenance is only a defect when nothing else shows the command
+    trained; see the comment on the `has_provenance` branch below.
     """
     if kind is CommandKind.RESERVED and not fell_back:
         return RowStatus.NOT_APPLICABLE
@@ -690,7 +695,17 @@ def _classify_status(
     if not has_provenance:
         if trains_as_label is False:
             return RowStatus.EXCLUDED
-        return RowStatus.MISSING
+        if not has_included_context:
+            # No generation record AND no sign the trainer ever reached this command:
+            # the run died part-way or provenance was lost. That is what MISSING means.
+            return RowStatus.MISSING
+        # An `UtteranceProvenance` record describes *generation*, and only
+        # `generate_diverse_utterances` writes one. A command whose `generate_utterances`
+        # returns hand-written rows directly never calls the generator, so it has nothing
+        # to record - exactly the reasoning `NOT_APPLICABLE` already applies to reserved
+        # labels. The trainer's own context provenance proves this command trained, and
+        # carries the row counts, so judge it on the floor like anything else instead of
+        # blocking publication over a record that was never owed.
     if rows_by_context and any(
         context_rows < min_rows for context_rows in rows_by_context.values()
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/radiantlogicinc/fastworkflow"
 
 [tool.poetry]
 name = "fastworkflow"
-version = "3.2.0"
+version = "3.2.1"
 description = "A framework for rapidly building large-scale, deterministic, interactive workflows with a fault-tolerant, conversational UX"
 authors = ["Dhar Rawal <drawal@radiantlogic.com>"]
 license = "Apache-2.0"

--- a/tests/test_heldout_evaluation.py
+++ b/tests/test_heldout_evaluation.py
@@ -9,6 +9,7 @@ testable without torch, a trained model, network access, or API keys.
 """
 
 import json
+import logging
 
 import pytest
 
@@ -20,6 +21,7 @@ from fastworkflow.model_pipeline_training import (
     _score_heldout_context,
     split_training_data,
 )
+from fastworkflow.utils.logging import logger as fastworkflow_logger
 from fastworkflow.nlu_labels import WILDCARD_LABEL
 from fastworkflow.train.selective_training import _recompute_heldout_totals
 from fastworkflow.train.heldout_evaluation import (
@@ -1120,15 +1122,45 @@ def test_rescue_threshold_matches_the_trainers_floor():
     assert any("floor" in note for note in split.notes)
 
 
+class _WarningSink(logging.Handler):
+    """Collects real `LogRecord`s off the real logger.
+
+    The `fastWorkflow` logger sets ``propagate = False``, so pytest's `caplog`, whose
+    handler lives on the root logger, never sees these records.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno == logging.WARNING:
+            self.messages.append(record.getMessage())
+
+
 def test_split_training_data_names_commands_not_encoded_ids():
-    """A developer cannot map label id 3 to a command without the LabelEncoder."""
+    """A developer cannot map label id 3 to a command without the LabelEncoder.
+
+    The thin label is now a warning rather than an abort - it trains unmeasured, the
+    way this module's own persona split already rescues a starved label - so the name
+    has to travel on the warning.
+    """
     dataset = [("only row", 3), ("a", 11), ("b", 11)]
 
-    with pytest.raises(TrainingDataError) as excinfo:
-        split_training_data(dataset, lambda encoded: f"TodoList/cmd_{encoded}")
+    sink = _WarningSink()
+    fastworkflow_logger.addHandler(sink)
+    try:
+        train_rows, evaluation_rows = split_training_data(
+            dataset, lambda encoded: f"TodoList/cmd_{encoded}"
+        )
+    finally:
+        fastworkflow_logger.removeHandler(sink)
 
-    assert "TodoList/cmd_3" in str(excinfo.value)
-    assert "[3]" not in str(excinfo.value)
+    assert ("only row", 3) in train_rows
+    assert 3 not in {label for _, label in evaluation_rows}
+    message = "\n".join(sink.messages)
+    assert "TodoList/cmd_3" in message
+    assert "[3]" not in message
 
 
 def test_report_discloses_which_model_was_evaluated(tmp_path):

--- a/tests/test_training_report.py
+++ b/tests/test_training_report.py
@@ -15,15 +15,19 @@ hand-written approximation of them.
 
 import importlib.util
 import json
+import logging
 import os
 import shutil
 
+import numpy as np
 import pytest
 from dotenv import dotenv_values
+from rich.console import Console
 
 import litellm
 
 import fastworkflow
+from fastworkflow.utils.logging import logger as fastworkflow_logger
 from fastworkflow.model_pipeline_training import TrainingDataError, split_training_data
 from fastworkflow.nlu_labels import PARAMETER_VALUE_LABEL, WILDCARD_LABEL
 from fastworkflow.train import heldout_evaluation
@@ -90,6 +94,39 @@ def workflow(tmp_path):
     for name in (tr.COMMAND_DIRECTORY_FILENAME, tr.ROUTING_DEFINITION_FILENAME):
         shutil.copy2(os.path.join(EXAMPLE_COMMAND_INFO, name), info / name)
     return str(folder)
+
+
+class _LogSink(logging.Handler):
+    """Collects real `LogRecord`s off the real logger.
+
+    The `fastWorkflow` logger sets ``propagate = False``, so pytest's `caplog`, whose
+    handler lives on the root logger, never sees these records. Attaching a stdlib
+    handler is not a mock: the records are the ones production emits.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def messages(self, level: int) -> list[str]:
+        return [r.getMessage() for r in self.records if r.levelno == level]
+
+
+@pytest.fixture
+def log_sink():
+    """Capture fastWorkflow log records for the duration of one test."""
+    sink = _LogSink()
+    previous_level = fastworkflow_logger.level
+    fastworkflow_logger.setLevel(logging.DEBUG)
+    fastworkflow_logger.addHandler(sink)
+    try:
+        yield sink
+    finally:
+        fastworkflow_logger.removeHandler(sink)
+        fastworkflow_logger.setLevel(previous_level)
 
 
 def _save_provenance(workflow_folderpath: str, *records: UtteranceProvenance) -> str:
@@ -374,6 +411,48 @@ def test_a_command_that_should_have_generated_but_did_not_is_reported_missing(wo
     assert "NO PROVENANCE" in tr.format_report(report)
 
 
+def test_hand_written_utterances_without_a_generator_call_are_not_missing(workflow):
+    """Only `generate_diverse_utterances` writes an `UtteranceProvenance` record.
+
+    A command whose `generate_utterances` returns hand-written rows directly never
+    calls the generator, so it has nothing to record - the same reasoning
+    NOT_APPLICABLE already applies to reserved labels. The trainer's own context
+    provenance proves it trained and carries the row count, so an absent generation
+    record must not block publication.
+    """
+    recorder = ProvenanceRecorder(workflow)
+    recorder.record_context(
+        context_name="*",
+        command_name=APP_COMMAND,
+        status=ContextTrainingStatus.INCLUDED,
+        row_count=4,
+    )
+    recorder.save()
+
+    row = _row(tr.build_report(workflow, min_rows=2, min_seeds=8), APP_COMMAND)
+
+    assert row.status is not tr.RowStatus.MISSING
+    assert row.is_blocking is False
+    assert row.row_count == 4
+
+
+def test_hand_written_utterances_below_the_floor_still_block(workflow):
+    """Exempting them from the provenance gate must not exempt them from the floor."""
+    recorder = ProvenanceRecorder(workflow)
+    recorder.record_context(
+        context_name="*",
+        command_name=APP_COMMAND,
+        status=ContextTrainingStatus.INCLUDED,
+        row_count=1,
+    )
+    recorder.save()
+
+    row = _row(tr.build_report(workflow, min_rows=2, min_seeds=8), APP_COMMAND)
+
+    assert row.status is tr.RowStatus.BELOW_FLOOR
+    assert row.is_blocking is True
+
+
 # ---------------------------------------------------------------------------
 # Reserved labels are not commands
 # ---------------------------------------------------------------------------
@@ -515,30 +594,70 @@ def test_class_aware_split_keeps_every_label_in_train_and_evaluation():
     assert {label for _, label in evaluation_rows} == {0, 1}
 
 
-def test_class_aware_split_fails_before_fitting_a_one_row_label():
-    # Matched against the constant rather than the spelled-out "two": the floor is
-    # now shared with the persona split (heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL)
-    # so the two modules cannot disagree, and the message interpolates it. Hard-coding
-    # the English here would break the moment the floor is retuned.
+def test_a_one_row_label_trains_unmeasured_instead_of_failing_the_run():
+    """A thin label costs its evaluation coverage, not the whole run.
+
+    The persona split already returns starved labels to train and records that they
+    have no held-out coverage. Aborting here instead spent the run's entire LLM and GPU
+    budget and then published nothing.
+    """
+    train_rows, evaluation_rows = split_training_data([
+        ("alpha one", 0),
+        ("alpha two", 0),
+        ("beta only", 1),
+    ])
+
+    assert ("beta only", 1) in train_rows, "the thin label must still reach the model"
+    assert 1 not in {label for _, label in evaluation_rows}, "and stay unmeasured"
+    assert 0 in {label for _, label in evaluation_rows}
+
+
+def test_a_one_row_label_is_named_in_a_warning_not_an_exception(log_sink):
+    split_training_data(
+        [("alpha one", 0), ("alpha two", 0), ("beta only", 1)],
+        lambda encoded: f"Ctx/command_{encoded}",
+    )
+
+    warnings = log_sink.messages(logging.WARNING)
+    assert any("Ctx/command_1" in message for message in warnings), (
+        "a developer cannot map label id 1 to a command without the LabelEncoder"
+    )
+    assert not any("Ctx/command_0" in message for message in warnings)
+
+
+def test_unmeasured_labels_are_named_as_plain_text_not_a_list_repr(log_sink):
+    """Regression: the report prints through a rich console.
+
+    `decode_label` returns a numpy string, so a list repr renders as
+    `[np.str_('cmd')]`; rich reads that bracketed run as markup and deletes it, which
+    silently dropped the one detail the message exists to carry.
+    """
+    split_training_data(
+        [("alpha one", 0), ("alpha two", 0), ("beta only", 1)],
+        lambda encoded: np.str_(f"Ctx/command_{encoded}"),
+    )
+
+    message = "\n".join(log_sink.messages(logging.WARNING))
+    assert "Ctx/command_1" in message
+    assert "np.str_" not in message
+    assert "[" not in message and "]" not in message
+    assert Console(width=200).render_str(message).plain.strip().endswith(
+        "Ctx/command_1"
+    ), "the label must survive a rich console"
+
+
+def test_a_dataset_where_nothing_can_be_measured_still_fails():
+    """No evaluation set at all is a different failure from one thin label.
+
+    Matched against the constant rather than the spelled-out "two": the floor is
+    shared with the persona split (heldout_evaluation.MIN_TRAINING_ROWS_PER_LABEL) so
+    the two modules cannot disagree, and the message interpolates it. Hard-coding the
+    English here would break the moment the floor is retuned.
+    """
     with pytest.raises(
-        TrainingDataError, match=f"at least {MIN_TRAINING_ROWS_PER_LABEL} rows"
+        TrainingDataError, match=f"{MIN_TRAINING_ROWS_PER_LABEL} rows"
     ):
-        split_training_data([
-            ("alpha one", 0),
-            ("alpha two", 0),
-            ("beta only", 1),
-        ])
-
-
-def test_class_aware_split_error_names_the_command_not_its_encoded_id():
-    """A developer cannot map label id 1 to a command without the LabelEncoder."""
-    with pytest.raises(TrainingDataError) as excinfo:
-        split_training_data(
-            [("alpha one", 0), ("alpha two", 0), ("beta only", 1)],
-            lambda encoded: f"Ctx/command_{encoded}",
-        )
-
-    assert "Ctx/command_1" in str(excinfo.value)
+        split_training_data([("alpha only", 0), ("beta only", 1)])
 
 
 def test_floor_environment_variables_are_ignored(workflow):


### PR DESCRIPTION
Training was failing for commands with a single utterance. Also missing provenance

## Summary by Sourcery

Make training resilient to thin intent labels and distinguish absent generation provenance from commands that trained successfully without using a generator.

Bug Fixes:
- Allow training to proceed when individual intent labels have too few rows for evaluation, while keeping those labels unmeasured and warning with readable command names.
- Correct training-report classification so hand-written utterances without generation provenance are not incorrectly reported as missing, while still enforcing row-count floors.

Enhancements:
- Improve label formatting in warnings and errors so decoded names remain readable and stable in console output.
- Retain a fatal error when no labels can produce an evaluation set at all.

Build:
- Bump the package version from 3.2.0 to 3.2.1.

Tests:
- Update training split and report coverage for thin labels, readable warnings, missing provenance, and floor enforcement.