### PR TITLE
fix(train): do not refuse publication for below-floor labels

### DIFF
--- a/fastworkflow/train/training_report.py
+++ b/fastworkflow/train/training_report.py
@@ -39,10 +39,11 @@ available at the end of a training run and can be retained with its artifacts.
 
 The two floors, and how much to trust them
 ------------------------------------------
-See `DEFAULT_MIN_TRAINING_ROWS` and `DEFAULT_MIN_SEED_UTTERANCES`. One is derived
-from a structural property of the training code; the other is an observation from
-a single workflow. They are labelled differently in the output on purpose, and
-only the structural floor can prevent publication.
+See `DEFAULT_MIN_TRAINING_ROWS` and `DEFAULT_MIN_SEED_UTTERANCES`. The row floor is
+derived from the minimum needed to both train and evaluate a label; falling below it
+means that label trains without evaluation coverage. The seed floor is an observation
+from a single workflow. Both are advisory because neither makes the trained label
+unusable.
 
 `TrainingReport.has_blocking_problems` rejects structurally unusable data before
 publication; fallback and seed-count findings remain advisory.
@@ -148,7 +149,8 @@ class RowStatus(str, Enum):
     #: Generation degraded (R3a fallback). The command trained on its command name
     #: plus hand-written seeds plus whatever arrived before the failure.
     FELL_BACK = "fell_back"
-    #: Fewer rows than the floor. May or may not have fallen back.
+    #: Fewer rows than the train-and-evaluate floor. The rows still train, but the
+    #: label has no evaluation coverage and is therefore reported as unmeasured.
     BELOW_FLOOR = "below_floor"
     #: The command has `Signature.Input`, but its generator returned no rows in at
     #: least one context. This is an explicit trainer skip, not missing provenance.
@@ -185,13 +187,12 @@ _STATUS_SEVERITY: dict[RowStatus, int] = {
     RowStatus.OK: 7,
 }
 
-#: Statuses that make a training dataset structurally unusable. EXCLUDED and
-#: THIN_SEEDS are deliberately absent: the first is a design choice, the second rests
-#: on one workflow's curve and is too weak a basis for rejecting a run. FELL_BACK is
-#: reported loudly but does not fail when enough rows remain.
+#: Statuses that make a training dataset structurally unusable. EXCLUDED is a design
+#: choice. THIN_SEEDS and BELOW_FLOOR are advisory: the former rests on one workflow's
+#: curve, while the latter means the label trained but could not also contribute an
+#: evaluation row. FELL_BACK is reported loudly but does not fail when rows remain.
 BLOCKING_STATUSES: frozenset[RowStatus] = frozenset(
     {
-        RowStatus.BELOW_FLOOR,
         RowStatus.NO_UTTERANCES,
         RowStatus.MISSING,
     }
@@ -1078,11 +1079,11 @@ def format_report(report: TrainingReport) -> str:
             f"  BELOW ROW FLOOR ({len(below_floor)}) — fewer than {report.min_rows} rows."
         )
         lines.append(
-            "  The class-aware split needs at least one row for training and one for "
-            "evaluation."
+            "  These labels trained, but the class-aware split could not also reserve "
+            "an evaluation row."
         )
         lines.append(
-            "  A label below that floor cannot be learned and evaluated in the same run."
+            "  They are unmeasured on the routing axis; this does not block publication."
         )
         lines.extend(_detail_lines(below_floor, width))
 
@@ -1227,7 +1228,7 @@ def format_report(report: TrainingReport) -> str:
 
     lines.append("")
     lines.append(
-        f"  Floors: rows >= {report.min_rows} (structural — one train and one "
+        f"  Floors: rows >= {report.min_rows} (evaluation coverage — one train and one "
         f"evaluation row per label),"
     )
     lines.append(
@@ -1235,9 +1236,7 @@ def format_report(report: TrainingReport) -> str:
         f"one workflow's"
     )
     lines.append("  observation). These are trainer policy, not workflow configuration.")
-    lines.append(
-        "  Structural failures stop publication; advisory findings do not."
-    )
+    lines.append("  Missing or empty training data stops publication; advisory findings do not.")
     lines.append(rule)
     return "\n".join(lines)
 

--- a/tests/test_training_report.py
+++ b/tests/test_training_report.py
@@ -337,14 +337,18 @@ def test_below_the_row_floor_is_flagged_separately_from_a_fallback(workflow):
 
     report = tr.build_report(workflow)
 
-    assert _row(report, APP_COMMAND).status is tr.RowStatus.BELOW_FLOOR
+    starved_row = _row(report, APP_COMMAND)
+    assert starved_row.status is tr.RowStatus.BELOW_FLOOR
+    assert starved_row.is_blocking is False
+    assert tr.RowStatus.BELOW_FLOOR not in tr.BLOCKING_STATUSES
     assert _row(report, FRAMEWORK_COMMAND).status is tr.RowStatus.OK
-    assert report.has_blocking_problems is True
+    assert starved_row not in report.blocking_rows
 
     rendered = tr.format_report(report)
     assert "BELOW ROW FLOOR" in rendered
-    # The floor's derivation travels with the number, so a reader is never left to
-    # assume it was measured.
+    assert "does not block publication" in rendered
+    # The floor's derivation travels with the number, so a reader knows exactly what
+    # was skipped rather than mistaking it for an accuracy threshold.
     assert "class-aware" in rendered
 
 
@@ -436,8 +440,8 @@ def test_hand_written_utterances_without_a_generator_call_are_not_missing(workfl
     assert row.row_count == 4
 
 
-def test_hand_written_utterances_below_the_floor_still_block(workflow):
-    """Exempting them from the provenance gate must not exempt them from the floor."""
+def test_hand_written_utterances_below_the_floor_train_unmeasured(workflow):
+    """A real row trains even when there is no second row to evaluate."""
     recorder = ProvenanceRecorder(workflow)
     recorder.record_context(
         context_name="*",
@@ -450,7 +454,7 @@ def test_hand_written_utterances_below_the_floor_still_block(workflow):
     row = _row(tr.build_report(workflow, min_rows=2, min_seeds=8), APP_COMMAND)
 
     assert row.status is tr.RowStatus.BELOW_FLOOR
-    assert row.is_blocking is True
+    assert row.is_blocking is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Follow-up to #75: that PR stopped *aborting mid-train* over a label with fewer than 2 rows, but `BELOW_FLOOR` remained in `BLOCKING_STATUSES`, so publication was still refused at the report gate (`Training data is structurally incomplete; refusing to publish models for: initialize_defect_info`).
- Remove `BELOW_FLOOR` from the publication blockers. A 1-row command still trains, is reported as unmeasured, and does not fail the run. `NO_UTTERANCES` and true `MISSING` (trainer never reached the command) still block.

## Test plan
- [x] `pytest tests/test_training_report.py tests/test_heldout_evaluation.py` (88 passed)
- [ ] Confirm a workflow with a single-utterance command (`talk_to_ido` / `initialize_defect_info`) publishes after train


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Allow below-floor labels to publish while continuing to block runs with missing or empty training data.

Bug Fixes:
- Allow labels with fewer than the evaluation row floor to train and publish without treating them as blocking failures.

Enhancements:
- Update training reports to identify below-floor labels as unmeasured and advisory while retaining publication blocking for missing or empty training data.

Tests:
- Update training report tests to verify below-floor labels are non-blocking and explicitly reported as unmeasured.